### PR TITLE
List flake versions matching a constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1450,6 +1451,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ regex = "1.9.4"
 tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "json"] }
 tracing = "0.1.37"
+urlencoding = "2.1.3"

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -11,6 +11,8 @@ use crate::cli::cmd::FlakeHubClient;
 
 use super::CommandExecute;
 
+pub(super) const FLAKEHUB_WEB_ROOT: &str = "https://flakehub.com";
+
 /// Lists key FlakeHub resources.
 #[derive(Parser)]
 pub(crate) struct ListSubcommand {
@@ -58,8 +60,8 @@ impl Flake {
         format!("{}/{}", self.org, self.project)
     }
 
-    fn url(&self, api_addr: &Url) -> String {
-        let mut url = api_addr.clone();
+    fn url(&self) -> String {
+        let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
         {
             let mut segs = url
                 .path_segments_mut()
@@ -124,7 +126,7 @@ impl CommandExecute for ListSubcommand {
                             for flake in flakes {
                                 table.add_row(Row::new(vec![
                                     Cell::new(&flake.name()).with_style(Attr::Bold),
-                                    Cell::new(&flake.url(&self.api_addr)).with_style(Attr::Dim),
+                                    Cell::new(&flake.url()).with_style(Attr::Dim),
                                 ]));
                             }
 
@@ -152,7 +154,7 @@ impl CommandExecute for ListSubcommand {
                             table.set_titles(row!["Organization", "FlakeHub URL"]);
 
                             for org in orgs {
-                                let mut url = self.api_addr.clone();
+                                let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
                                 {
                                     let mut segs = url.path_segments_mut().expect(
                                         "flakehub url cannot be base (this should never happen)",
@@ -228,12 +230,10 @@ impl CommandExecute for ListSubcommand {
                             ]);
 
                             for version in versions {
-                                let mut flakehub_root = self.api_addr.clone();
+                                let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
 
                                 {
-                                    let mut path_segments_mut = flakehub_root
-                                        .path_segments_mut()
-                                        .expect(
+                                    let mut path_segments_mut = url.path_segments_mut().expect(
                                         "flakehub url cannot be base (this should never happen)",
                                     );
 
@@ -247,8 +247,7 @@ impl CommandExecute for ListSubcommand {
                                 table.add_row(Row::new(vec![
                                     Cell::new(&version.simplified_version).with_style(Attr::Bold),
                                     Cell::new(&version.version).with_style(Attr::Dim),
-                                    Cell::new(flakehub_root.as_ref())
-                                        .with_style(Attr::Underline(true)),
+                                    Cell::new(url.as_ref()).with_style(Attr::Underline(true)),
                                 ]));
                             }
 

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -225,8 +225,8 @@ impl CommandExecute for ListSubcommand {
                             table.set_format(*TABLE_FORMAT);
                             table.set_titles(row![
                                 "Simplified version",
+                                "FlakeHub URL",
                                 "Full version",
-                                "FlakeHub URL"
                             ]);
 
                             for version in versions {
@@ -246,8 +246,8 @@ impl CommandExecute for ListSubcommand {
 
                                 table.add_row(Row::new(vec![
                                     Cell::new(&version.simplified_version).with_style(Attr::Bold),
+                                    Cell::new(url.as_ref()).with_style(Attr::Dim),
                                     Cell::new(&version.version).with_style(Attr::Dim),
-                                    Cell::new(url.as_ref()).with_style(Attr::Underline(true)),
                                 ]));
                             }
 

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -212,7 +212,7 @@ impl CommandExecute for ListSubcommand {
                                 table.add_row(Row::new(vec![
                                     Cell::new(&version.simplified_version).with_style(Attr::Bold),
                                     Cell::new(&version.version).with_style(Attr::Dim),
-                                    Cell::new(&flakehub_root.to_string())
+                                    Cell::new(flakehub_root.as_ref())
                                         .with_style(Attr::Underline(true)),
                                 ]));
                             }

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -61,7 +61,12 @@ enum Subcommands {
     /// List all releases for a specific flake on FlakeHub.
     Releases { flake: String },
     /// List all versions that match the provided version constraint.
-    Versions { flake: String, constraint: String },
+    Versions {
+        /// The flake for which you want to list compatible versions.
+        flake: String,
+        /// The version constraint as a string.
+        constraint: String,
+    },
 }
 
 #[async_trait::async_trait]

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -61,7 +61,8 @@ impl Flake {
     }
 
     fn url(&self) -> String {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
+        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
+            .expect("failed to parse flakehub web root url (this should never happen)");
         {
             let mut segs = url
                 .path_segments_mut()
@@ -153,8 +154,11 @@ impl CommandExecute for ListSubcommand {
                             table.set_format(*TABLE_FORMAT);
                             table.set_titles(row!["Organization", "FlakeHub URL"]);
 
+                            let mut url = Url::parse(FLAKEHUB_WEB_ROOT).expect(
+                                "failed to parse flakehub web root url (this should never happen)",
+                            );
+
                             for org in orgs {
-                                let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
                                 {
                                     let mut segs = url.path_segments_mut().expect(
                                         "flakehub url cannot be base (this should never happen)",
@@ -230,7 +234,9 @@ impl CommandExecute for ListSubcommand {
                             ]);
 
                             for version in versions {
-                                let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
+                                let mut url = Url::parse(FLAKEHUB_WEB_ROOT).expect(
+                                    "failed to parse flakehub web root url (this should never happen)",
+                                );
 
                                 {
                                     let mut path_segments_mut = url.path_segments_mut().expect(

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -105,10 +105,9 @@ impl CommandExecute for ListSubcommand {
                                 table.to_csv(std::io::stdout())?;
                             }
                         }
+                        Ok(ExitCode::SUCCESS)
                     }
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                    }
+                    Err(e) => Err(e.into()),
                 }
             }
             Orgs => {
@@ -137,10 +136,9 @@ impl CommandExecute for ListSubcommand {
                                 table.to_csv(std::io::stdout())?;
                             }
                         }
+                        Ok(ExitCode::SUCCESS)
                     }
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                    }
+                    Err(e) => Err(e.into()),
                 }
             }
             Releases { flake } => {
@@ -165,10 +163,9 @@ impl CommandExecute for ListSubcommand {
                                 table.to_csv(std::io::stdout())?;
                             }
                         }
+                        Ok(ExitCode::SUCCESS)
                     }
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                    }
+                    Err(e) => Err(e.into()),
                 }
             }
             Versions { flake, constraint } => {
@@ -196,14 +193,11 @@ impl CommandExecute for ListSubcommand {
                                 table.to_csv(std::io::stdout())?;
                             }
                         }
+                        Ok(ExitCode::SUCCESS)
                     }
-                    Err(e) => {
-                        eprintln!("Error: {e}");
-                    }
+                    Err(e) => Err(e.into()),
                 }
             }
         }
-
-        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -8,7 +8,11 @@ use reqwest::Client as HttpClient;
 
 use crate::cli::cmd::list::Org;
 
-use self::{list::Flake, list::Release, search::SearchResult};
+use self::{
+    list::Flake,
+    list::{Release, Version},
+    search::SearchResult,
+};
 
 lazy_static! {
     pub(super) static ref TABLE_FORMAT: TableFormat = FormatBuilder::new()
@@ -126,5 +130,23 @@ impl FlakeHubClient {
             .collect();
 
         Ok(orgs)
+    }
+
+    async fn versions(&self, flake: String, constraint: String) -> Result<Vec<Version>, FhError> {
+        let version = urlencoding::encode(&constraint);
+
+        let endpoint = self
+            .api_addr
+            .join(&format!("versions/{}/{}", flake, version))?;
+
+        let versions = self
+            .client
+            .get(endpoint)
+            .send()
+            .await?
+            .json::<Vec<Version>>()
+            .await?;
+
+        Ok(versions)
     }
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -154,7 +154,11 @@ impl FlakeHubClient {
             let mut segs = endpoint
                 .path_segments_mut()
                 .expect("flakehub url cannot be base (this should never happen)");
-            segs.push("versions").push(org).push(project).push(&version);
+            segs.push("version")
+                .push("resolve")
+                .push(org)
+                .push(project)
+                .push(&version);
         }
 
         let versions = self

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -104,16 +104,13 @@ impl FlakeHubClient {
         Ok(flakes)
     }
 
-    async fn releases(&self, flake: Flake) -> Result<Vec<Release>, FhError> {
+    async fn releases(&self, org: &str, project: &str) -> Result<Vec<Release>, FhError> {
         let mut endpoint = self.api_addr.clone();
         {
             let mut segs = endpoint
                 .path_segments_mut()
                 .expect("flakehub url cannot be base (this should never happen)");
-            segs.push("f")
-                .push(&flake.org)
-                .push(&flake.project)
-                .push("releases");
+            segs.push("f").push(org).push(project).push("releases");
         }
 
         let flakes = self
@@ -144,18 +141,20 @@ impl FlakeHubClient {
         Ok(orgs)
     }
 
-    async fn versions(&self, flake: Flake, constraint: String) -> Result<Vec<Version>, FhError> {
-        let version = urlencoding::encode(&constraint);
+    async fn versions(
+        &self,
+        org: &str,
+        project: &str,
+        constraint: &str,
+    ) -> Result<Vec<Version>, FhError> {
+        let version = urlencoding::encode(constraint);
 
         let mut endpoint = self.api_addr.clone();
         {
             let mut segs = endpoint
                 .path_segments_mut()
                 .expect("flakehub url cannot be base (this should never happen)");
-            segs.push("versions")
-                .push(&flake.org)
-                .push(&flake.project)
-                .push(&version);
+            segs.push("versions").push(org).push(project).push(&version);
         }
 
         let versions = self

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -31,7 +31,8 @@ impl SearchResult {
     }
 
     fn url(&self) -> String {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
+        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
+            .expect("failed to parse flakehub web root url (this should never happen)");
         {
             let mut segs = url
                 .path_segments_mut()

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -4,7 +4,7 @@ use prettytable::{row, Attr, Cell, Row, Table};
 use std::process::ExitCode;
 use url::Url;
 
-use super::{CommandExecute, FlakeHubClient, TABLE_FORMAT};
+use super::{list::FLAKEHUB_WEB_ROOT, CommandExecute, FlakeHubClient, TABLE_FORMAT};
 
 /// Searches FlakeHub for flakes that match your query.
 #[derive(Debug, Parser)]
@@ -30,8 +30,8 @@ impl SearchResult {
         format!("{}/{}", self.org, self.project)
     }
 
-    fn url(&self, api_addr: &Url) -> String {
-        let mut url = api_addr.clone();
+    fn url(&self) -> String {
+        let mut url = Url::parse(FLAKEHUB_WEB_ROOT).unwrap();
         {
             let mut segs = url
                 .path_segments_mut()
@@ -62,10 +62,10 @@ impl CommandExecute for SearchSubcommand {
                     let results: Vec<&SearchResult> =
                         results.iter().take(self.max_results).collect();
 
-                    for flake in results {
+                    for result in results {
                         table.add_row(Row::new(vec![
-                            Cell::new(&flake.name()).with_style(Attr::Bold),
-                            Cell::new(&flake.url(&self.api_addr)).with_style(Attr::Dim),
+                            Cell::new(&result.name()).with_style(Attr::Bold),
+                            Cell::new(&result.url()).with_style(Attr::Dim),
                         ]));
                     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,6 @@
 pub(crate) mod cmd;
 mod instrumentation;
 
-// For use in console output
-pub(super) const FLAKEHUB_WEB_ROOT: &str = "https://flakehub.com";
-
 /// fh: a CLI for interacting with FlakeHub
 #[derive(clap::Parser)]
 pub(crate) struct Cli {


### PR DESCRIPTION
Examples:

```shell
fh list versions nixos/nixpkgs "0.2305.*"
fh list versions DeterminateSystems/nuenv "*"
fh list versions eza-community/eza "0.10"
```

Note that this requires a backend change (currently in review).

<img width="716" alt="image" src="https://github.com/DeterminateSystems/fh/assets/1523104/c5dea7c2-f593-4b43-8355-581fc353b495">
