### PR TITLE
Enable listing flakes by label

### DIFF
--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -155,6 +155,8 @@ impl CommandExecute for ListSubcommand {
                     return Err(FhError::LabelParse(String::from("whitespace not allowed")).into());
                 }
 
+                let label = label.to_lowercase();
+
                 match client.flakes_by_label(&label).await {
                     Ok(flakes) => {
                         if flakes.is_empty() {

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -151,7 +151,7 @@ impl CommandExecute for ListSubcommand {
                 }
             }
             Label { label } => {
-                if string_has_whitespace(label.clone()) {
+                if string_has_whitespace(&label) {
                     return Err(FhError::LabelParse(String::from("whitespace not allowed")).into());
                 }
 
@@ -325,6 +325,6 @@ impl CommandExecute for ListSubcommand {
     }
 }
 
-fn string_has_whitespace(s: String) -> bool {
+fn string_has_whitespace(s: &str) -> bool {
     s.chars().any(char::is_whitespace)
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -137,7 +137,7 @@ impl FlakeHubClient {
                 .path_segments_mut()
                 .expect("flakehub url cannot be base (this should never happen)");
 
-            segs.push("tag").push(label); // TODO: update the backend URL
+            segs.push("label").push(label);
         }
 
         let flakes = self

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -10,8 +10,7 @@ use reqwest::Client as HttpClient;
 use serde::Serialize;
 
 use self::{
-    list::Flake,
-    list::{Org, Release, Version},
+    list::{Flake, Org, Release, Version},
     search::SearchResult,
 };
 
@@ -61,6 +60,9 @@ pub(super) enum FhError {
 
     #[error("json parsing error: {0}")]
     Json(#[from] serde_json::Error),
+
+    #[error("label parsing error: {0}")]
+    LabelParse(String),
 
     #[error("the flake has no inputs")]
     NoInputs,
@@ -120,6 +122,27 @@ impl FlakeHubClient {
         let flakes = self
             .client
             .get(endpoint)
+            .send()
+            .await?
+            .json::<Vec<Flake>>()
+            .await?;
+
+        Ok(flakes)
+    }
+
+    async fn flakes_by_label(&self, label: &str) -> Result<Vec<Flake>, FhError> {
+        let mut url = self.api_addr.clone();
+        {
+            let mut segs = url
+                .path_segments_mut()
+                .expect("flakehub url cannot be base (this should never happen)");
+
+            segs.push("tag").push(label); // TODO: update the backend URL
+        }
+
+        let flakes = self
+            .client
+            .get(&url.to_string())
             .send()
             .await?
             .json::<Vec<Flake>>()


### PR DESCRIPTION
I'm marking this as a draft because it depends on backend changes, namely returning project/org for the flake instead of name/org. I could've used Serde aliasing for that but I'd prefer to streamline the backend instead.