### PR TITLE
Additional inputs

### DIFF
--- a/src/cli/cmd/add/flake.rs
+++ b/src/cli/cmd/add/flake.rs
@@ -46,7 +46,7 @@ pub(crate) fn update_flake_input(
             replace_input_value_uri(&existing_input_value, &flake_input_value, &flake_contents)
         }
         otherwise => {
-            // OK technically it can be an IndentedString but I don't want to support that so yeah
+            // Unclear what this case could be
             Err(color_eyre::eyre::eyre!(
                 "`inputs.{flake_input_name}.url` was not a String, Indented String, or URI. Instead: {:?}", // this is enforced by Nix itself
                 otherwise

--- a/src/cli/cmd/add/flake.rs
+++ b/src/cli/cmd/add/flake.rs
@@ -46,7 +46,7 @@ pub(crate) fn update_flake_input(
             replace_input_value_uri(&existing_input_value, &flake_input_value, &flake_contents)
         }
         otherwise => {
-            // Unclear what this case could be
+            // a boolean, a number, or even another attrset, etc.
             Err(color_eyre::eyre::eyre!(
                 "`inputs.{flake_input_name}.url` was not a String, Indented String, or URI. Instead: {:?}", // this is enforced by Nix itself
                 otherwise
@@ -109,6 +109,7 @@ pub(crate) fn collect_all_inputs(
         let name_parts = match name_parts {
             Some(n) => n,
             None => {
+                tracing::trace!("skipped input because we didn't get Raw parts");
                 continue;
             }
         };
@@ -123,9 +124,6 @@ pub(crate) fn collect_all_inputs(
         .entered();
 
         match name_parts[..] {
-            [] => {
-                tracing::trace!("Surprise null case");
-            }
             ["inputs"] => {
                 all_inputs.extend(find_all_attrsets_by_path(&v.to, None)?);
             }

--- a/src/cli/cmd/add/flake.rs
+++ b/src/cli/cmd/add/flake.rs
@@ -35,6 +35,11 @@ pub(crate) fn update_flake_input(
             &flake_input_value,
             &flake_contents,
         ),
+        nixel::Expression::IndentedString(existing_input_value) => replace_input_value_string(
+            &existing_input_value.parts,
+            &flake_input_value,
+            &flake_contents,
+        ),
         nixel::Expression::Uri(existing_input_value) => {
             replace_input_value_uri(&existing_input_value, &flake_input_value, &flake_contents)
         }

--- a/src/cli/cmd/convert.rs
+++ b/src/cli/cmd/convert.rs
@@ -466,6 +466,9 @@ fn find_input_value_by_path(
                 _ => None,
             });
         }
+        nixel::Expression::Uri(u) => {
+            found_value = Some(u.uri.trim().to_string());
+        }
         t => {
             let start = t.start();
             return Err(color_eyre::eyre::eyre!(

--- a/src/cli/cmd/convert.rs
+++ b/src/cli/cmd/convert.rs
@@ -7,9 +7,10 @@ use once_cell::sync::Lazy;
 
 use super::CommandExecute;
 
-// match {nixos,nixpkgs}-YY.MM branches
+// match {nixos,nixpkgs,releases}-YY.MM branches
 static RELEASE_BRANCH_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
-    regex::Regex::new(r"(nixos|nixpkgs)-(?<year>[[:digit:]]{2})\.(?<month>[[:digit:]]{2})").unwrap()
+    regex::Regex::new(r"(nixos|nixpkgs|release)-(?<year>[[:digit:]]{2})\.(?<month>[[:digit:]]{2})")
+        .unwrap()
 });
 
 const NIXPKGS_IMPLICIT_INPUT_NAME: &str = "nixpkgs";

--- a/src/cli/cmd/convert.rs
+++ b/src/cli/cmd/convert.rs
@@ -8,7 +8,7 @@ use tracing::{span, Level};
 
 use super::CommandExecute;
 
-// match {nixos,nixpkgs,releases}-YY.MM branches
+// match {nixos,nixpkgs,release}-YY.MM branches
 static RELEASE_BRANCH_REGEX: Lazy<regex::Regex> = Lazy::new(|| {
     regex::Regex::new(r"(nixos|nixpkgs|release)-(?<year>[[:digit:]]{2})\.(?<month>[[:digit:]]{2})")
         .unwrap()
@@ -133,7 +133,7 @@ impl ConvertSubcommand {
             let _span_guard = span.enter();
 
             let url = find_input_value_by_path(&input.to, ["url".into()].into())?;
-            tracing::debug!("Input URL as written: {:?}", url);
+            tracing::debug!("Current input's `url` value: {:?}", url);
 
             let url = match url {
                 Some(url) => {

--- a/src/cli/cmd/convert.rs
+++ b/src/cli/cmd/convert.rs
@@ -466,6 +466,12 @@ fn find_input_value_by_path(
                 _ => None,
             });
         }
+        nixel::Expression::IndentedString(s) => {
+            found_value = s.parts.first().and_then(|part| match part {
+                nixel::Part::Raw(raw) => Some(raw.content.trim().to_string()),
+                _ => None,
+            });
+        }
         nixel::Expression::Uri(u) => {
             found_value = Some(u.uri.trim().to_string());
         }


### PR DESCRIPTION
Extends convert to support more cases.

URI-types become strings:

```diff
     fenix = {
-      url = github:nix-community/fenix;
+      url = "https://flakehub.com/f/nix-community/fenix/0.1.1618.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs";
     };
```

and IndentedStrings, such as they are, are converted too:

```diff
-     flake-utils.url = ''github:numtide/flake-utils'';
+     flake-utils.url = ''https://flakehub.com/f/numtide/flake-utils/0.1.87.tar.gz'';
```

and nixpkgs/release-mm.yy are supported -- migrated to releases now.

Also, while running fh across every determinatesystems project, I found another issue. When a flake.nix looks like this:

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";

  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
```

`rust-overlay`'s input URL appears to be replaced with "nixpkgs", causing the result to be:

```
{
  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.532072.tar.gz";

  inputs.rust-overlay.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.532072.tar.gz";
  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
```

I fixed this as well by not considering `inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";` to be an input line.