### PR TITLE
Add support for `flake-compat` to `fh init`

### DIFF
--- a/assets/default.nix
+++ b/assets/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/assets/default.nix
+++ b/assets/default.nix
@@ -2,7 +2,7 @@
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
-      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      url = lock.nodes.flake-compat.locked.url;
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )

--- a/assets/default.nix
+++ b/assets/default.nix
@@ -2,7 +2,7 @@
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
-      url = lock.nodes.flake-compat.locked.url;
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )

--- a/assets/flake.hbs
+++ b/assets/flake.hbs
@@ -15,14 +15,7 @@
       inputs.{{this.follows}}.follows = "{{{this.follows}}}";
     };
     {{else}}
-    {{#if (is_false this.flake)}}
-    {{@key}} = {
-      url = "{{{this.reference}}}";
-      flake = false;
-    };
-    {{else}}
     {{@key}}.url = "{{{this.reference}}}";
-    {{/if}}
     {{/if}}
     {{#unless @last}}
 

--- a/assets/flake.hbs
+++ b/assets/flake.hbs
@@ -14,6 +14,11 @@
       url = "{{{this.reference}}}";
       inputs.{{this.follows}}.follows = "{{{this.follows}}}";
     };
+    {{else if this.not_a_flake}}
+    {{@key}} = {
+      url = "{{{this.reference}}}";
+      flake = false;
+    };
     {{else}}
     {{@key}}.url = "{{{this.reference}}}";
     {{/if}}

--- a/assets/flake.hbs
+++ b/assets/flake.hbs
@@ -14,13 +14,15 @@
       url = "{{{this.reference}}}";
       inputs.{{this.follows}}.follows = "{{{this.follows}}}";
     };
-    {{else if this.not_a_flake}}
+    {{else}}
+    {{#if (is_false this.flake)}}
     {{@key}} = {
       url = "{{{this.reference}}}";
       flake = false;
     };
     {{else}}
     {{@key}}.url = "{{{this.reference}}}";
+    {{/if}}
     {{/if}}
     {{#unless @last}}
 

--- a/assets/shell.nix
+++ b/assets/shell.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix

--- a/assets/shell.nix
+++ b/assets/shell.nix
@@ -2,7 +2,7 @@
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      url = lock.nodes.flake-compat.locked.url;
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )

--- a/assets/shell.nix
+++ b/assets/shell.nix
@@ -2,7 +2,7 @@
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
-      url = lock.nodes.flake-compat.locked.url;
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )

--- a/src/cli/cmd/init/handlers/mod.rs
+++ b/src/cli/cmd/init/handlers/mod.rs
@@ -31,15 +31,13 @@ use super::{dev_shell::DevShell, project::Project};
 pub(crate) struct Input {
     pub(crate) reference: String,
     pub(crate) follows: Option<String>,
-    pub(crate) flake: bool,
 }
 
-impl Default for Input {
-    fn default() -> Self {
+impl Input {
+    pub(crate) fn new(reference: &str, follows: Option<&str>) -> Self {
         Self {
-            reference: String::new(),
-            follows: None,
-            flake: true,
+            reference: String::from(reference),
+            follows: follows.map(|f| f.to_owned()),
         }
     }
 }

--- a/src/cli/cmd/init/handlers/mod.rs
+++ b/src/cli/cmd/init/handlers/mod.rs
@@ -31,6 +31,7 @@ use super::{dev_shell::DevShell, project::Project};
 pub(crate) struct Input {
     pub(crate) reference: String,
     pub(crate) follows: Option<String>,
+    pub(crate) flake: bool,
 }
 
 #[derive(Default)]

--- a/src/cli/cmd/init/handlers/mod.rs
+++ b/src/cli/cmd/init/handlers/mod.rs
@@ -34,6 +34,16 @@ pub(crate) struct Input {
     pub(crate) flake: bool,
 }
 
+impl Default for Input {
+    fn default() -> Self {
+        Self {
+            reference: String::new(),
+            follows: None,
+            flake: true,
+        }
+    }
+}
+
 #[derive(Default)]
 pub(crate) struct Flake {
     pub(crate) description: Option<String>,

--- a/src/cli/cmd/init/handlers/php.rs
+++ b/src/cli/cmd/init/handlers/php.rs
@@ -11,11 +11,10 @@ impl Handler for Php {
         if project.has_one_of(&["composer.json", "php.ini"]) && Prompt::for_language("PHP") {
             flake.inputs.insert(
                 String::from("loophp"),
-                Input {
-                    reference: String::from("https://flakehub.com/f/loophp/nix-shell/0.1.*.tar.gz"),
-                    follows: Some(String::from("nixpkgs")),
-                    ..Default::default()
-                },
+                Input::new(
+                    "https://flakehub.com/f/loophp/nix-shell/0.1.*.tar.gz",
+                    Some("nixpkgs"),
+                ),
             );
             flake
                 .overlay_refs

--- a/src/cli/cmd/init/handlers/php.rs
+++ b/src/cli/cmd/init/handlers/php.rs
@@ -1,6 +1,6 @@
 use crate::cli::cmd::init::{project::Project, prompt::Prompt};
 
-use super::{version_as_attr, Flake, Handler};
+use super::{version_as_attr, Flake, Handler, Input};
 
 const PHP_VERSIONS: &[&str] = &["8.3", "8.2", "8.1", "8.0", "7.4", "7.3"];
 
@@ -11,7 +11,7 @@ impl Handler for Php {
         if project.has_one_of(&["composer.json", "php.ini"]) && Prompt::for_language("PHP") {
             flake.inputs.insert(
                 String::from("loophp"),
-                super::Input {
+                Input {
                     reference: String::from("https://flakehub.com/f/loophp/nix-shell/0.1.*.tar.gz"),
                     follows: Some(String::from("nixpkgs")),
                     ..Default::default()

--- a/src/cli/cmd/init/handlers/php.rs
+++ b/src/cli/cmd/init/handlers/php.rs
@@ -14,6 +14,7 @@ impl Handler for Php {
                 super::Input {
                     reference: String::from("https://flakehub.com/f/loophp/nix-shell/0.1.*.tar.gz"),
                     follows: Some(String::from("nixpkgs")),
+                    flake: true,
                 },
             );
             flake

--- a/src/cli/cmd/init/handlers/php.rs
+++ b/src/cli/cmd/init/handlers/php.rs
@@ -14,7 +14,7 @@ impl Handler for Php {
                 super::Input {
                     reference: String::from("https://flakehub.com/f/loophp/nix-shell/0.1.*.tar.gz"),
                     follows: Some(String::from("nixpkgs")),
-                    flake: true,
+                    ..Default::default()
                 },
             );
             flake

--- a/src/cli/cmd/init/handlers/rust.rs
+++ b/src/cli/cmd/init/handlers/rust.rs
@@ -16,7 +16,7 @@ impl Handler for Rust {
                 Input {
                     reference: String::from("github:oxalica/rust-overlay"),
                     follows: Some(String::from("nixpkgs")),
-                    flake: true,
+                    ..Default::default()
                 },
             );
 

--- a/src/cli/cmd/init/handlers/rust.rs
+++ b/src/cli/cmd/init/handlers/rust.rs
@@ -13,11 +13,7 @@ impl Handler for Rust {
         if project.has_file("Cargo.toml") && Prompt::for_language("Rust") {
             flake.inputs.insert(
                 String::from("rust-overlay"),
-                Input {
-                    reference: String::from("github:oxalica/rust-overlay"),
-                    follows: Some(String::from("nixpkgs")),
-                    ..Default::default()
-                },
+                Input::new("github:oxalica/rust-overlay", Some("nixpkgs")),
             );
 
             flake

--- a/src/cli/cmd/init/handlers/rust.rs
+++ b/src/cli/cmd/init/handlers/rust.rs
@@ -16,6 +16,7 @@ impl Handler for Rust {
                 Input {
                     reference: String::from("github:oxalica/rust-overlay"),
                     follows: Some(String::from("nixpkgs")),
+                    flake: true,
                 },
             );
 

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -129,6 +129,7 @@ impl CommandExecute for InitSubcommand {
                 Input {
                     reference: nixpkgs_version,
                     follows: None,
+                    flake: true,
                 },
             );
 
@@ -137,6 +138,7 @@ impl CommandExecute for InitSubcommand {
                 Input {
                     reference: FlakeHubUrl::latest("DeterminateSystems", "flake-schemas"),
                     follows: None,
+                    flake: true,
                 },
             );
 
@@ -212,6 +214,27 @@ impl CommandExecute for InitSubcommand {
                     env_vars: flake.env_vars,
                 },
             );
+
+            if Prompt::bool(
+                "Would you like to make your project usable for Nix users who don't use flakes?",
+            ) {
+                flake.inputs.insert(
+                    String::from("flake-compat"),
+                    Input {
+                        reference: FlakeHubUrl::latest("edolstra", "flake-compat"),
+                        follows: None,
+                        flake: false,
+                    },
+                );
+                write(
+                    PathBuf::from("default.nix"),
+                    String::from(include_str!("../../../../assets/default.nix")),
+                )?;
+                write(
+                    PathBuf::from("shell.nix"),
+                    String::from(include_str!("../../../../assets/shell.nix")),
+                )?;
+            }
 
             let data = TemplateData {
                 description: flake.description,

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -220,8 +220,8 @@ impl CommandExecute for InitSubcommand {
                     String::from("flake-compat"),
                     Input {
                         reference: FlakeHubUrl::latest("edolstra", "flake-compat"),
-                        follows: None,
                         flake: false,
+                        ..Default::default()
                     },
                 );
                 write(

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -247,7 +247,10 @@ impl CommandExecute for InitSubcommand {
 
             if project.has_directory(".git")
                 && command_exists("git")
-                && Prompt::bool("Would you like to add your new Nix files to Git?")
+                && Prompt::bool(&format!(
+                    "Would you like to add your new Nix {} to Git?",
+                    if use_flake_compat { "files" } else { "file" }
+                ))
             {
                 Command::new("git")
                     .args(["add", "--intent-to-add", "flake.nix"])

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -210,7 +210,7 @@ impl CommandExecute for InitSubcommand {
             );
 
             let use_flake_compat = Prompt::bool(
-                "Would you like to make your project usable for Nix users who don't use flakes?",
+                "Would you like to support legacy Nix commands like `nix-build` and `nix-shell`?",
             );
 
             if use_flake_compat {

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -124,20 +124,16 @@ impl CommandExecute for InitSubcommand {
                 _ => return Err(FhError::Unreachable(String::from("nixpkgs selection")).into()),
             };
 
-            flake.inputs.insert(
-                String::from("nixpkgs"),
-                Input {
-                    reference: nixpkgs_version,
-                    ..Default::default()
-                },
-            );
+            flake
+                .inputs
+                .insert(String::from("nixpkgs"), Input::new(&nixpkgs_version, None));
 
             flake.inputs.insert(
                 String::from("flake-schemas"),
-                Input {
-                    reference: FlakeHubUrl::latest("DeterminateSystems", "flake-schemas"),
-                    ..Default::default()
-                },
+                Input::new(
+                    &FlakeHubUrl::latest("DeterminateSystems", "flake-schemas"),
+                    None,
+                ),
             );
 
             // Languages
@@ -218,11 +214,7 @@ impl CommandExecute for InitSubcommand {
             ) {
                 flake.inputs.insert(
                     String::from("flake-compat"),
-                    Input {
-                        reference: FlakeHubUrl::latest("edolstra", "flake-compat"),
-                        flake: false,
-                        ..Default::default()
-                    },
+                    Input::new(&FlakeHubUrl::latest("edolstra", "flake-compat"), None),
                 );
                 write(
                     PathBuf::from("default.nix"),

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -247,7 +247,7 @@ impl CommandExecute for InitSubcommand {
 
             if project.has_directory(".git")
                 && command_exists("git")
-                && Prompt::bool("Would you like to add your new files to Git?")
+                && Prompt::bool("Would you like to add your new Nix files to Git?")
             {
                 Command::new("git")
                     .args(["add", "--intent-to-add", "flake.nix"])

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -209,9 +209,11 @@ impl CommandExecute for InitSubcommand {
                 },
             );
 
-            if Prompt::bool(
+            let use_flake_compat = Prompt::bool(
                 "Would you like to make your project usable for Nix users who don't use flakes?",
-            ) {
+            );
+
+            if use_flake_compat {
                 flake.inputs.insert(
                     String::from("flake-compat"),
                     Input::new(&FlakeHubUrl::latest("edolstra", "flake-compat"), None),
@@ -245,11 +247,17 @@ impl CommandExecute for InitSubcommand {
 
             if project.has_directory(".git")
                 && command_exists("git")
-                && Prompt::bool("Would you like to add your flake.nix file to Git?")
+                && Prompt::bool("Would you like to add your new files to Git?")
             {
                 Command::new("git")
                     .args(["add", "--intent-to-add", "flake.nix"])
                     .output()?;
+
+                if use_flake_compat {
+                    Command::new("git")
+                        .args(["add", "--intent-to-add", "default.nix", "shell.nix"])
+                        .output()?;
+                }
             }
 
             if !project.has_file(".envrc")

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -128,8 +128,7 @@ impl CommandExecute for InitSubcommand {
                 String::from("nixpkgs"),
                 Input {
                     reference: nixpkgs_version,
-                    follows: None,
-                    flake: true,
+                    ..Default::default()
                 },
             );
 
@@ -137,8 +136,7 @@ impl CommandExecute for InitSubcommand {
                 String::from("flake-schemas"),
                 Input {
                     reference: FlakeHubUrl::latest("DeterminateSystems", "flake-schemas"),
-                    follows: None,
-                    flake: true,
+                    ..Default::default()
                 },
             );
 

--- a/src/cli/cmd/init/template.rs
+++ b/src/cli/cmd/init/template.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use handlebars::{handlebars_helper, Handlebars};
+use handlebars::Handlebars;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -25,8 +25,6 @@ pub(super) struct TemplateData {
     pub(super) doc_comments: bool,
 }
 
-handlebars_helper!(is_false: |b: bool| !b);
-
 impl TemplateData {
     pub(super) fn as_json(&self) -> Result<Value, serde_json::Error> {
         serde_json::to_value(self)
@@ -44,10 +42,6 @@ impl TemplateData {
         self.validate()?;
 
         let mut handlebars = Handlebars::new();
-
-        // This helper is necessary because `not x` in Handlebars could mean `x = false` or it
-        // could mean that `x` is not defined, so we need a specific handler for the `x = false` case.
-        handlebars.register_helper("is_false", Box::new(is_false));
 
         handlebars
             .register_template_string("flake", include_str!("../../../../assets/flake.hbs"))

--- a/src/cli/cmd/init/template.rs
+++ b/src/cli/cmd/init/template.rs
@@ -45,8 +45,8 @@ impl TemplateData {
 
         let mut handlebars = Handlebars::new();
 
-        // This helper is necessary because Handlebars `not x` in Handlebars could mean `x = false` or it
-        // could mean that `x` is not defined. So we need a specific handler for the Boolean case.
+        // This helper is necessary because `not x` in Handlebars could mean `x = false` or it
+        // could mean that `x` is not defined, so we need a specific handler for the `x = false` case.
         handlebars.register_helper("is_false", Box::new(is_false));
 
         handlebars


### PR DESCRIPTION
This PR adds support for `flake-compat` to the `fh init` command. If you say yes to the prompt, you get a `default.nix`, a `shell.nix`, and a `flake-compat` input in your `flake.nix`.

I've tested that this works using these steps:

```shell
# Empty project

fh init

# Say "yes" to prompt re: Nix users who don't use flakes

nix-shell

[nix-shell:~/example-flake]$ which curl
/nix/store/kmiapnigv92jwhpzqk2w9mjk0y8y8s6b-curl-8.1.1-bin/bin/curl
```