### PR TITLE
Trim trailing /s from flakerefs

### DIFF
--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -118,6 +118,7 @@ async fn infer_flake_input_name_url(
     flake_ref: String,
     input_name: Option<String>,
 ) -> color_eyre::Result<(String, url::Url)> {
+    let flake_ref = flake_ref.trim_end_matches('/');
     let url_result = flake_ref.parse::<url::Url>();
 
     match url_result {

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -144,6 +144,11 @@ async fn infer_flake_input_name_url(
                 [org, project, version] => {
                     let version = version.strip_suffix(".tar.gz").unwrap_or(version);
                     let version = version.strip_prefix('v').unwrap_or(version);
+                    semver::VersionReq::parse(version).map_err(|_| {
+                        color_eyre::eyre::eyre!(
+                            "version '{version}' was not a valid SemVer version requirement"
+                        )
+                    })?;
 
                     (org, project, Some(version))
                 }

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -153,11 +153,10 @@ async fn infer_flake_input_name_url(
                     (org, project, Some(version))
                 }
                 // `nixos/nixpkgs`
-                [org, project] => {
-                    (org, project, None)
-                }
+                [org, project] => (org, project, None),
                 _ => Err(color_eyre::eyre::eyre!(
-                    "flakehub input did not match the expected format of `org/project` or `org/project/version`"
+                    "flakehub input did not match the expected format of \
+                    `org/project` or `org/project/version`"
                 ))?,
             };
 


### PR DESCRIPTION
Treats ryantm/agenix/ the same as ryantm/agenix.

---

Fixes https://github.com/DeterminateSystems/fh/issues/66.