### PR TITLE
version_as_attr_default

### DIFF
--- a/src/cli/cmd/init/handlers/mod.rs
+++ b/src/cli/cmd/init/handlers/mod.rs
@@ -61,6 +61,10 @@ pub(crate) trait Handler {
 }
 
 // Helper functions
-fn version_as_attr(v: &str) -> String {
-    v.replace('.', "")
+fn version_as_attr(v: &str, substring: &str) -> String {
+    v.replace('.', substring)
+}
+
+fn version_as_attr_default(v: &str) -> String {
+    version_as_attr(v, "")
 }

--- a/src/cli/cmd/init/handlers/php.rs
+++ b/src/cli/cmd/init/handlers/php.rs
@@ -1,6 +1,6 @@
 use crate::cli::cmd::init::{project::Project, prompt::Prompt};
 
-use super::{version_as_attr, Flake, Handler, Input};
+use super::{version_as_attr_default, Flake, Handler, Input};
 
 const PHP_VERSIONS: &[&str] = &["8.3", "8.2", "8.1", "8.0", "7.4", "7.3"];
 
@@ -20,7 +20,7 @@ impl Handler for Php {
                 .overlay_refs
                 .push(String::from("loophp.overlays.default"));
             let php_version = Prompt::select("Select a version of PHP", PHP_VERSIONS);
-            let php_version_attr = version_as_attr(&php_version);
+            let php_version_attr = version_as_attr_default(&php_version);
             flake
                 .dev_shell_packages
                 .push(format!("php{php_version_attr}"));

--- a/src/cli/cmd/init/handlers/python.rs
+++ b/src/cli/cmd/init/handlers/python.rs
@@ -1,6 +1,6 @@
 use crate::cli::cmd::init::{project::Project, prompt::Prompt};
 
-use super::{version_as_attr, Flake, Handler};
+use super::{version_as_attr_default, Flake, Handler};
 
 const PYTHON_VERSIONS: &[&str] = &["3.11", "3.10", "3.09"];
 const PYTHON_TOOLS: &[&str] = &["pip", "virtualenv", "pipenv"];
@@ -11,7 +11,7 @@ impl Handler for Python {
     fn handle(project: &Project, flake: &mut Flake) {
         if project.has_one_of(&["setup.py", "requirements.txt"]) && Prompt::for_language("Python") {
             let python_version = Prompt::select("Select a version of Python", PYTHON_VERSIONS);
-            let python_version_attr = version_as_attr(&python_version);
+            let python_version_attr = version_as_attr_default(&python_version);
             flake
                 .dev_shell_packages
                 .push(format!("python{python_version_attr}"));

--- a/src/cli/cmd/init/handlers/ruby.rs
+++ b/src/cli/cmd/init/handlers/ruby.rs
@@ -11,7 +11,7 @@ impl Handler for Ruby {
         if project.has_one_of(&["Gemfile", "config.ru", "Rakefile"]) && Prompt::for_language("Ruby")
         {
             let ruby_version = Prompt::select("Select a version of Ruby", RUBY_VERSIONS);
-            let ruby_version_attr = version_as_attr(&ruby_version);
+            let ruby_version_attr = version_as_attr(&ruby_version, "_");
             flake
                 .dev_shell_packages
                 .push(format!("ruby_{ruby_version_attr}"));


### PR DESCRIPTION
With this change ruby_version_attr will be ruby_3_2 and not ruby_32 which is not a valid package.

Fixes https://github.com/DeterminateSystems/fh/issues/77