### PR TITLE
Detect bun.lockb file

### DIFF
--- a/src/cli/cmd/init/handlers/javascript.rs
+++ b/src/cli/cmd/init/handlers/javascript.rs
@@ -13,7 +13,7 @@ impl Handler for JavaScript {
         }
 
         if project.has_file("package.json") && Prompt::for_language("JavaScript/TypeScript") {
-            if project.has_file("bunfig.toml")
+            if project.has_one_of(&["bunfig.toml", "bun.lockb"])
                 && Prompt::bool(
                     "This seems to be a Bun project. Would you like to add it to your environment?",
                 )


### PR DESCRIPTION
This improves our detection of Bun, as I suspect `bun.lockb` files are more widely used than `bunfig.toml` (though I could be wrong).