### PR TITLE
Bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "fh"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fh"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Determinate Systems <hello@determinate.systems>"]
 edition = "2021"
 license = "Apache 2.0"

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -34,7 +34,7 @@ pub(crate) struct AddSubcommand {
     pub(crate) input_name: Option<String>,
     /// The flake reference to add as an input.
     ///
-    /// A reference in the form of `NixOS/nixpkgs` or `NixOS/nixpkgs/0.2305.*` (without a URL
+    /// A reference in the form of `NixOS/nixpkgs` or `NixOS/nixpkgs/0.2311.*` (without a URL
     /// scheme) will be inferred as a FlakeHub input.
     pub(crate) input_ref: String,
     /// Whether to insert a new input at the top of or the bottom of an existing `inputs` attrset.
@@ -138,10 +138,10 @@ async fn infer_flake_input_name_url(
                 ))
             }
         }
-        // A URL like `nixos/nixpkgs` or `nixos/nixpkgs/0.2305`
+        // A URL like `nixos/nixpkgs` or `nixos/nixpkgs/0.2311`
         Err(url::ParseError::RelativeUrlWithoutBase) => {
             let (org, project, version) = match flake_ref.split('/').collect::<Vec<_>>()[..] {
-                // `nixos/nixpkgs/0.2305`
+                // `nixos/nixpkgs/0.2311`
                 [org, project, version] => {
                     let version = version.strip_suffix(".tar.gz").unwrap_or(version);
                     let version = version.strip_prefix('v').unwrap_or(version);

--- a/src/cli/cmd/eject/mod.rs
+++ b/src/cli/cmd/eject/mod.rs
@@ -373,13 +373,13 @@ mod test {
         let server_url = server_addr.parse().unwrap();
 
         let input_url =
-            url::Url::parse("https://flakehub.com/f/nixos/nixpkgs/0.2305.*.tar.gz").unwrap();
+            url::Url::parse("https://flakehub.com/f/nixos/nixpkgs/0.2311.*.tar.gz").unwrap();
         let github_url = super::eject_input_to_github(&server_url, input_url)
             .await
             .ok()
             .flatten()
             .unwrap();
-        assert_eq!(github_url.to_string(), "github:nixos/nixpkgs/nixos-23.05");
+        assert_eq!(github_url.to_string(), "github:nixos/nixpkgs/nixos-23.11");
     }
 
     #[tokio::test]

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -61,8 +61,8 @@ impl FlakeHubUrl {
 }
 
 // Nixpkgs references
-const NIXPKGS_LATEST: &str = "latest stable (currently 23.05)";
-const NIXPKGS_23_05: &str = "23.05";
+const NIXPKGS_LATEST: &str = "latest stable (currently 23.11)";
+const NIXPKGS_23_11: &str = "23.11";
 const NIXPKGS_UNSTABLE: &str = "unstable";
 const NIXPKGS_SPECIFIC: &str = "select a specific release (not recommended in most cases)";
 
@@ -108,7 +108,7 @@ impl CommandExecute for InitSubcommand {
                 "Which Nixpkgs version would you like to include?",
                 &[
                     NIXPKGS_LATEST,
-                    NIXPKGS_23_05,
+                    NIXPKGS_23_11,
                     NIXPKGS_UNSTABLE,
                     NIXPKGS_SPECIFIC,
                 ],
@@ -117,7 +117,7 @@ impl CommandExecute for InitSubcommand {
             {
                 // MAYBE: find an enum-based approach to this
                 NIXPKGS_LATEST => FlakeHubUrl::latest("NixOS", "nixpkgs"),
-                NIXPKGS_23_05 => FlakeHubUrl::version("NixOS", "nixpkgs", "0.2305.*"),
+                NIXPKGS_23_11 => FlakeHubUrl::version("NixOS", "nixpkgs", "0.2311.*"),
                 NIXPKGS_UNSTABLE => FlakeHubUrl::unstable("NixOS", "nixpkgs"),
                 NIXPKGS_SPECIFIC => select_nixpkgs(&self.api_addr).await?,
                 // Just in case


### PR DESCRIPTION
There's nothing really "new" in this release per se, but we're bumping this on the pragmatic grounds that it will un-break people trying to run it from `*.tar.gz`.
