### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "fh"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fh"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Determinate Systems <hello@determinate.systems>"]
 edition = "2021"
 license = "Apache 2.0"


### PR DESCRIPTION
Now that fh supports login, it seems like a reasonable time for a minor version bump.
