### PR TITLE
Add ARM builds to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,25 @@ on:
     branches: [main]
 
 jobs:
+  build-artifacts-ARM64-macOS:
+    runs-on: macos-latest-xlarge
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build package
+        run: |
+          nix build .# -L
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: fh-ARM64-macOS
+          path: result/bin/fh
+          retention-days: 1
+
   build-artifacts-X64-macOS:
     runs-on: macos-12
     steps:
@@ -18,7 +37,7 @@ jobs:
       - name: Build package
         run: |
           nix build .# -L
-          
+
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -42,5 +61,25 @@ jobs:
         uses: actions/upload-artifact@v3.1.2
         with:
           name: fh-X64-Linux
+          path: result/bin/fh
+          retention-days: 1
+
+  build-artifacts-ARM64-Linux:
+    runs-on: namespace-profile-default-arm64
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build package
+        run: |
+          nix build .# -L
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          # Artifact name
+          name: fh-ARM64-Linux
           path: result/bin/fh
           retention-days: 1


### PR DESCRIPTION
An oversight on our part. This bring `fh` in line with `flake-checker` and other projects.
