### PR TITLE
Add authentication to core FlakeHub client

### DIFF
--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -189,5 +189,5 @@ pub(crate) async fn get_flakehub_project_and_url(
     project: &str,
     version: Option<&str>,
 ) -> color_eyre::Result<(String, url::Url)> {
-    Ok(FlakeHubClient::project_and_url(api_addr.as_ref(), org, project, version).await?)
+    FlakeHubClient::project_and_url(api_addr.as_ref(), org, project, version).await
 }

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -217,8 +217,8 @@ pub(crate) async fn get_flakehub_project_and_url(
         .build()?;
 
     let flakehub_json_url = match version {
-        Some(version) => flakehub_url!(&api_addr.to_string(), "version", org, project, version),
-        None => flakehub_url!(&api_addr.to_string(), "f", org, project),
+        Some(version) => flakehub_url!(api_addr.as_ref(), "version", org, project, version),
+        None => flakehub_url!(api_addr.as_ref(), "f", org, project),
     };
 
     #[derive(Debug, Deserialize)]

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -189,6 +189,5 @@ pub(crate) async fn get_flakehub_project_and_url(
     project: &str,
     version: Option<&str>,
 ) -> color_eyre::Result<(String, url::Url)> {
-    let client = FlakeHubClient::new(api_addr);
-    Ok(client.project_and_url(org, project, version).await?)
+    Ok(FlakeHubClient::project_and_url(api_addr.as_ref(), org, project, version).await?)
 }

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -7,14 +7,10 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use color_eyre::eyre::WrapErr;
-use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION};
-use serde::Deserialize;
-
-use crate::flakehub_url;
 
 use self::flake::InputsInsertionLocation;
 
-use super::CommandExecute;
+use super::{CommandExecute, FlakeHubClient};
 
 const FALLBACK_FLAKE_CONTENTS: &str = r#"{
   description = "My new flake.";
@@ -193,49 +189,6 @@ pub(crate) async fn get_flakehub_project_and_url(
     project: &str,
     version: Option<&str>,
 ) -> color_eyre::Result<(String, url::Url)> {
-    let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
-
-    let xdg = xdg::BaseDirectories::new()?;
-    // $XDG_CONFIG_HOME/fh/auth; basically ~/.config/fh/auth
-    let token_path = xdg.get_config_file("flakehub/auth");
-
-    if token_path.exists() {
-        let token = tokio::fs::read_to_string(&token_path)
-            .await
-            .wrap_err_with(|| format!("Could not open {}", token_path.display()))?;
-
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {token}"))?,
-        );
-    }
-
-    let client = reqwest::Client::builder()
-        .user_agent(crate::APP_USER_AGENT)
-        .default_headers(headers)
-        .build()?;
-
-    let flakehub_json_url = match version {
-        Some(version) => flakehub_url!(api_addr.as_ref(), "version", org, project, version),
-        None => flakehub_url!(api_addr.as_ref(), "f", org, project),
-    };
-
-    #[derive(Debug, Deserialize)]
-    struct ProjectCanonicalNames {
-        project: String,
-        // FIXME: detect Nix version and strip .tar.gz if it supports it
-        pretty_download_url: url::Url,
-    }
-
-    let res = client.get(&flakehub_json_url.to_string()).send().await?;
-
-    if let Err(e) = res.error_for_status_ref() {
-        let err_text = res.text().await?;
-        return Err(e).wrap_err(err_text)?;
-    };
-
-    let res = res.json::<ProjectCanonicalNames>().await?;
-
-    Ok((res.project, res.pretty_download_url))
+    let client = FlakeHubClient::new(api_addr);
+    Ok(client.project_and_url(org, project, version).await?)
 }

--- a/src/cli/cmd/eject/mod.rs
+++ b/src/cli/cmd/eject/mod.rs
@@ -276,7 +276,7 @@ async fn get_metadata_from_flakehub(
         .default_headers(headers)
         .build()?;
 
-    let flakehub_json_url = flakehub_url!(&api_addr.to_string(), "version", org, project, version);
+    let flakehub_json_url = flakehub_url!(api_addr.as_ref(), "version", org, project, version);
 
     let res = client.get(&flakehub_json_url.to_string()).send().await?;
 

--- a/src/cli/cmd/eject/mod.rs
+++ b/src/cli/cmd/eject/mod.rs
@@ -241,8 +241,7 @@ async fn get_metadata_from_flakehub(
     project: &str,
     version: &str,
 ) -> color_eyre::Result<ProjectMetadata> {
-    let client = FlakeHubClient::new(api_addr);
-    Ok(client.metadata(org, project, version).await?)
+    Ok(FlakeHubClient::metadata(api_addr.as_ref(), org, project, version).await?)
 }
 
 #[cfg(test)]

--- a/src/cli/cmd/eject/mod.rs
+++ b/src/cli/cmd/eject/mod.rs
@@ -174,7 +174,7 @@ async fn eject_flakehub_input_to_github(
         source_github_owner_repo_pair,
         source_subdirectory,
         version,
-    } = get_metadata_from_flakehub(api_addr, org, project, version).await?;
+    } = FlakeHubClient::metadata(api_addr.as_ref(), org, project, version).await?;
 
     let maybe_version_or_branch = match source_github_owner_repo_pair.to_lowercase().as_str() {
         "nixos/nixpkgs" => {
@@ -232,16 +232,6 @@ fn separate_year_from_month_in_version(version: &str) -> Option<String> {
     };
 
     version
-}
-
-#[tracing::instrument(skip_all)]
-async fn get_metadata_from_flakehub(
-    api_addr: &url::Url,
-    org: &str,
-    project: &str,
-    version: &str,
-) -> color_eyre::Result<ProjectMetadata> {
-    Ok(FlakeHubClient::metadata(api_addr.as_ref(), org, project, version).await?)
 }
 
 #[cfg(test)]

--- a/src/cli/cmd/eject/mod.rs
+++ b/src/cli/cmd/eject/mod.rs
@@ -9,6 +9,8 @@ use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION};
 use serde::Deserialize;
 use tracing::{span, Level};
 
+use crate::flakehub_url;
+
 use super::CommandExecute;
 
 static ROLLING_RELEASE_BUILD_META_REGEX: Lazy<regex::Regex> =
@@ -274,18 +276,7 @@ async fn get_metadata_from_flakehub(
         .default_headers(headers)
         .build()?;
 
-    let mut flakehub_json_url = api_addr.clone();
-    {
-        let mut path_segments_mut = flakehub_json_url
-            .path_segments_mut()
-            .expect("flakehub url cannot be base (this should never happen)");
-
-        path_segments_mut
-            .push("version")
-            .push(org)
-            .push(project)
-            .push(version);
-    }
+    let flakehub_json_url = flakehub_url!(&api_addr.to_string(), "version", org, project, version);
 
     let res = client.get(&flakehub_json_url.to_string()).send().await?;
 

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -15,7 +15,10 @@ use std::{
 };
 use url::Url;
 
-use crate::cli::cmd::{init::handlers::Elm, list::FLAKEHUB_WEB_ROOT};
+use crate::{
+    cli::cmd::{init::handlers::Elm, list::FLAKEHUB_WEB_ROOT},
+    flakehub_url,
+};
 
 use super::FlakeHubClient;
 
@@ -36,20 +39,8 @@ pub(crate) struct FlakeHubUrl;
 
 impl FlakeHubUrl {
     fn version(org: &str, project: &str, version: &str) -> String {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-
         let version = format!("{version}.tar.gz");
-
-        {
-            let mut segs = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            segs.push("f").push(org).push(project).push(&version);
-        }
-
-        url.to_string()
+        flakehub_url!(FLAKEHUB_WEB_ROOT, "f", org, project, &version).to_string()
     }
 
     fn latest(org: &str, project: &str) -> String {

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -284,7 +284,7 @@ fn command_exists(cmd: &str) -> bool {
 }
 
 async fn select_nixpkgs(api_addr: &Url) -> Result<String, FhError> {
-    let client = FlakeHubClient::new(api_addr, false).await?;
+    let client = FlakeHubClient::new(api_addr);
     let releases = client.releases("NixOS", "nixpkgs").await?;
     let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
     let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -284,8 +284,7 @@ fn command_exists(cmd: &str) -> bool {
 }
 
 async fn select_nixpkgs(api_addr: &Url) -> Result<String, FhError> {
-    let client = FlakeHubClient::new(api_addr);
-    let releases = client.releases("NixOS", "nixpkgs").await?;
+    let releases = FlakeHubClient::releases(api_addr.as_ref(), "NixOS", "nixpkgs").await?;
     let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
     let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);
     Ok(FlakeHubUrl::version("NixOS", "nixpkgs", &release))

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -34,24 +34,6 @@ use self::{
 
 use super::{CommandExecute, FhError};
 
-// A helper struct for creating FlakeHub URLs
-pub(crate) struct FlakeHubUrl;
-
-impl FlakeHubUrl {
-    fn version(org: &str, project: &str, version: &str) -> String {
-        let version = format!("{version}.tar.gz");
-        flakehub_url!(FLAKEHUB_WEB_ROOT, "f", org, project, &version).to_string()
-    }
-
-    fn latest(org: &str, project: &str) -> String {
-        Self::version(org, project, "*")
-    }
-
-    fn unstable(org: &str, project: &str) -> String {
-        Self::version(org, project, "0.1.*")
-    }
-}
-
 // Nixpkgs references
 const NIXPKGS_LATEST: &str = "latest stable (currently 24.05)";
 const NIXPKGS_24_05: &str = "24.05";
@@ -108,22 +90,34 @@ impl CommandExecute for InitSubcommand {
             .as_str()
             {
                 // MAYBE: find an enum-based approach to this
-                NIXPKGS_LATEST => FlakeHubUrl::latest("NixOS", "nixpkgs"),
-                NIXPKGS_24_05 => FlakeHubUrl::version("NixOS", "nixpkgs", "0.2405.*"),
-                NIXPKGS_UNSTABLE => FlakeHubUrl::unstable("NixOS", "nixpkgs"),
-                NIXPKGS_SPECIFIC => select_nixpkgs(&self.api_addr).await?,
+                NIXPKGS_LATEST => flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "*"),
+                NIXPKGS_24_05 => {
+                    flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.2405.*")
+                }
+                NIXPKGS_UNSTABLE => {
+                    flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.1.*")
+                }
+                NIXPKGS_SPECIFIC => select_nixpkgs(self.api_addr.as_ref()).await?,
                 // Just in case
                 _ => return Err(FhError::Unreachable(String::from("nixpkgs selection")).into()),
             };
 
-            flake
-                .inputs
-                .insert(String::from("nixpkgs"), Input::new(&nixpkgs_version, None));
+            flake.inputs.insert(
+                String::from("nixpkgs"),
+                Input::new(nixpkgs_version.as_ref(), None),
+            );
 
             flake.inputs.insert(
                 String::from("flake-schemas"),
                 Input::new(
-                    &FlakeHubUrl::latest("DeterminateSystems", "flake-schemas"),
+                    flakehub_url!(
+                        FLAKEHUB_WEB_ROOT,
+                        "f",
+                        "DeterminateSystems",
+                        "flake-schemas",
+                        "*"
+                    )
+                    .as_str(),
                     None,
                 ),
             );
@@ -209,7 +203,11 @@ impl CommandExecute for InitSubcommand {
             if use_flake_compat {
                 flake.inputs.insert(
                     String::from("flake-compat"),
-                    Input::new(&FlakeHubUrl::latest("edolstra", "flake-compat"), None),
+                    Input::new(
+                        flakehub_url!(FLAKEHUB_WEB_ROOT, "flake", "edolstra", "flake-compat", "*")
+                            .as_str(),
+                        None,
+                    ),
                 );
                 write(
                     PathBuf::from("default.nix"),
@@ -283,9 +281,16 @@ fn command_exists(cmd: &str) -> bool {
     Command::new(cmd).output().is_ok()
 }
 
-async fn select_nixpkgs(api_addr: &Url) -> Result<String, FhError> {
-    let releases = FlakeHubClient::releases(api_addr.as_ref(), "NixOS", "nixpkgs").await?;
+async fn select_nixpkgs(api_addr: &str) -> Result<Url, FhError> {
+    let releases = FlakeHubClient::releases(api_addr, "NixOS", "nixpkgs").await?;
     let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
     let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);
-    Ok(FlakeHubUrl::version("NixOS", "nixpkgs", &release))
+    let version = format!("{release}.tar.gz");
+    Ok(flakehub_url!(
+        FLAKEHUB_WEB_ROOT,
+        "f",
+        "NixOS",
+        "nixpkgs",
+        &version
+    ))
 }

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -293,7 +293,7 @@ fn command_exists(cmd: &str) -> bool {
 }
 
 async fn select_nixpkgs(api_addr: &Url) -> Result<String, FhError> {
-    let client = &FlakeHubClient::new(api_addr)?;
+    let client = FlakeHubClient::new(api_addr, false).await?;
     let releases = client.releases("NixOS", "nixpkgs").await?;
     let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
     let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -8,7 +8,10 @@ use tabled::{Table, Tabled};
 use url::Url;
 
 use super::{print_json, FhError};
-use crate::cli::cmd::{FlakeHubClient, DEFAULT_STYLE};
+use crate::{
+    cli::cmd::{FlakeHubClient, DEFAULT_STYLE},
+    flakehub_url,
+};
 
 use super::CommandExecute;
 
@@ -40,16 +43,7 @@ impl Flake {
     }
 
     fn url(&self) -> Url {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-        {
-            let mut segs = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            segs.push("flake").push(&self.org).push(&self.project);
-        }
-        url
+        flakehub_url!(FLAKEHUB_WEB_ROOT, "flake", &self.org, &self.project)
     }
 }
 
@@ -298,20 +292,11 @@ struct OrgRow {
 
 impl From<Org> for OrgRow {
     fn from(value: Org) -> Self {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-
-        {
-            let mut segs = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            segs.push("org").push(&value.name);
-        }
+        let flakehub_url = flakehub_url!(FLAKEHUB_WEB_ROOT, "org", &value.name);
 
         Self {
             organization: value.name,
-            flakehub_url: url,
+            flakehub_url,
         }
     }
 }
@@ -331,25 +316,18 @@ struct VersionRow {
 
 impl From<(Flake, Version)> for VersionRow {
     fn from((flake, version): (Flake, Version)) -> Self {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-
-        {
-            let mut path_segments_mut = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            path_segments_mut
-                .push("flake")
-                .push(&flake.org)
-                .push(&flake.project)
-                .push(&version.simplified_version.to_string());
-        }
+        let flakehub_url = flakehub_url!(
+            FLAKEHUB_WEB_ROOT,
+            "flake",
+            &flake.org,
+            &flake.project,
+            &version.simplified_version.to_string()
+        );
 
         Self {
             simplified_version: version.simplified_version,
-            flakehub_url: url,
             full_version: version.version,
+            flakehub_url,
         }
     }
 }
@@ -366,17 +344,6 @@ struct FlakeRow {
 
 impl From<Flake> for FlakeRow {
     fn from(value: Flake) -> Self {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-
-        {
-            let mut segs = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            segs.push("org").push(&value.org);
-        }
-
         Self {
             flake: value.name(),
             flakehub_url: value.url(),

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -110,14 +110,12 @@ impl CommandExecute for ListSubcommand {
     async fn execute(self) -> color_eyre::Result<ExitCode> {
         use Subcommands::*;
 
-        let client = FlakeHubClient::new(&self.api_addr);
-
         match self.cmd {
             Flakes => {
                 let pb = ProgressBar::new_spinner();
                 pb.set_style(ProgressStyle::default_spinner());
 
-                match client.flakes().await {
+                match FlakeHubClient::flakes(self.api_addr.as_ref()).await {
                     Ok(flakes) => {
                         if flakes.is_empty() {
                             eprintln!("No results");
@@ -150,7 +148,7 @@ impl CommandExecute for ListSubcommand {
 
                 let label = label.to_lowercase();
 
-                match client.flakes_by_label(&label).await {
+                match FlakeHubClient::flakes_by_label(self.api_addr.as_ref(), &label).await {
                     Ok(flakes) => {
                         if flakes.is_empty() {
                             eprintln!("No results");
@@ -180,7 +178,7 @@ impl CommandExecute for ListSubcommand {
                 let pb = ProgressBar::new_spinner();
                 pb.set_style(ProgressStyle::default_spinner());
 
-                match client.orgs().await {
+                match FlakeHubClient::orgs(self.api_addr.as_ref()).await {
                     Ok(orgs) => {
                         if orgs.is_empty() {
                             eprintln!("No results");
@@ -210,7 +208,9 @@ impl CommandExecute for ListSubcommand {
 
                 let flake = Flake::try_from(flake)?;
 
-                match client.releases(&flake.org, &flake.project).await {
+                match FlakeHubClient::releases(self.api_addr.as_ref(), &flake.org, &flake.project)
+                    .await
+                {
                     Ok(releases) => {
                         let rows = releases
                             .into_iter()
@@ -241,9 +241,13 @@ impl CommandExecute for ListSubcommand {
 
                 let flake = Flake::try_from(flake)?.clone();
 
-                match client
-                    .versions(&flake.org, &flake.project, &constraint)
-                    .await
+                match FlakeHubClient::versions(
+                    self.api_addr.as_ref(),
+                    &flake.org,
+                    &flake.project,
+                    &constraint,
+                )
+                .await
                 {
                     Ok(versions) => {
                         if versions.is_empty() {

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -116,7 +116,7 @@ impl CommandExecute for ListSubcommand {
     async fn execute(self) -> color_eyre::Result<ExitCode> {
         use Subcommands::*;
 
-        let client = FlakeHubClient::new(&self.api_addr)?;
+        let client = FlakeHubClient::new(&self.api_addr, true).await?;
 
         match self.cmd {
             Flakes => {

--- a/src/cli/cmd/list.rs
+++ b/src/cli/cmd/list.rs
@@ -110,7 +110,7 @@ impl CommandExecute for ListSubcommand {
     async fn execute(self) -> color_eyre::Result<ExitCode> {
         use Subcommands::*;
 
-        let client = FlakeHubClient::new(&self.api_addr, true).await?;
+        let client = FlakeHubClient::new(&self.api_addr);
 
         match self.cmd {
             Flakes => {

--- a/src/cli/cmd/login/mod.rs
+++ b/src/cli/cmd/login/mod.rs
@@ -4,6 +4,8 @@ use std::process::ExitCode;
 use clap::Parser;
 use tokio::io::AsyncWriteExt;
 
+use crate::cli::cmd::FlakeHubClient;
+
 use super::{CommandExecute, FhError};
 
 const CACHE_PUBLIC_KEYS: &[&str; 2] = &[
@@ -57,11 +59,7 @@ impl LoginSubcommand {
         let (token, status) = match token {
             Some(token) => {
                 // This serves as validating that provided token is actually a JWT, and is valid.
-                let status = crate::cli::cmd::status::get_status_from_auth_token(
-                    self.api_addr.clone(),
-                    &token,
-                )
-                .await?;
+                let status = FlakeHubClient::auth_status(self.api_addr.as_ref(), &token).await?;
                 (token, status)
             }
             None => {

--- a/src/cli/cmd/login/mod.rs
+++ b/src/cli/cmd/login/mod.rs
@@ -4,7 +4,7 @@ use std::process::ExitCode;
 use clap::Parser;
 use tokio::io::AsyncWriteExt;
 
-use super::CommandExecute;
+use super::{CommandExecute, FhError};
 
 const CACHE_PUBLIC_KEYS: &[&str; 2] = &[
     "cache.flakehub.com-1:t6986ugxCA+d/ZF9IeMzJkyqi5mDhvFIx7KA/ipulzE=",
@@ -325,7 +325,7 @@ async fn upsert_user_nix_config(
     Ok(())
 }
 
-pub(crate) fn auth_token_path() -> color_eyre::Result<PathBuf> {
+pub(crate) fn auth_token_path() -> Result<PathBuf, FhError> {
     let xdg = xdg::BaseDirectories::new()?;
     // $XDG_CONFIG_HOME/fh/auth; basically ~/.config/fh/auth
     let token_path = xdg.place_config_file("flakehub/auth")?;

--- a/src/cli/cmd/login/mod.rs
+++ b/src/cli/cmd/login/mod.rs
@@ -325,7 +325,7 @@ async fn upsert_user_nix_config(
 
 pub(crate) fn auth_token_path() -> Result<PathBuf, FhError> {
     let xdg = xdg::BaseDirectories::new()?;
-    // $XDG_CONFIG_HOME/fh/auth; basically ~/.config/fh/auth
+    // $XDG_CONFIG_HOME/flakehub/auth; basically ~/.config/flakehub/auth
     let token_path = xdg.place_config_file("flakehub/auth")?;
 
     Ok(token_path)

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -195,6 +195,7 @@ impl FlakeHubClient {
 
         let res = client.get(&url.to_string()).send().await?;
 
+        // Enrich the CLI error text with the error returned by FlakeHub
         if let Err(e) = res.error_for_status_ref() {
             let err_text = res.text().await?;
             return Err(e).wrap_err(err_text)?;
@@ -217,10 +218,13 @@ impl FlakeHubClient {
         };
         let client = make_base_client(true).await?;
         let res = client.get(&url.to_string()).send().await?;
+
+        // Enrich the CLI error text with the error returned by FlakeHub
         if let Err(e) = res.error_for_status_ref() {
             let err_text = res.text().await?;
             return Err(e).wrap_err(err_text)?;
         };
+
         let res = res.json::<ProjectCanonicalNames>().await?;
         Ok((res.project, res.pretty_download_url))
     }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -8,8 +8,12 @@ pub(crate) mod login;
 pub(crate) mod search;
 pub(crate) mod status;
 
+use color_eyre::eyre::WrapErr;
 use once_cell::sync::Lazy;
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION};
+use reqwest::{
+    header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION},
+    Client,
+};
 use serde::{Deserialize, Serialize};
 use tabled::settings::{
     style::{HorizontalLine, On, VerticalLineIter},
@@ -107,6 +111,20 @@ pub(crate) enum FhError {
     Xdg(#[from] xdg::BaseDirectoriesError),
 }
 
+#[derive(Debug, Deserialize)]
+struct ProjectMetadata {
+    source_github_owner_repo_pair: String,
+    source_subdirectory: Option<String>,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectCanonicalNames {
+    project: String,
+    // FIXME: detect Nix version and strip .tar.gz if it supports it
+    pretty_download_url: url::Url,
+}
+
 impl FlakeHubClient {
     pub(crate) fn new(api_addr: &url::Url) -> Self {
         Self(api_addr.to_string())
@@ -117,24 +135,7 @@ impl FlakeHubClient {
         params: Option<Vec<(&str, String)>>,
         authenticated: bool,
     ) -> Result<T, FhError> {
-        let mut headers = HeaderMap::new();
-        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
-
-        if authenticated {
-            if let Ok(token) = tokio::fs::read_to_string(auth_token_path()?).await {
-                if !token.is_empty() {
-                    headers.insert(
-                        AUTHORIZATION,
-                        HeaderValue::from_str(&format!("Bearer {}", token.trim()))?,
-                    );
-                }
-            }
-        }
-
-        let client = reqwest::Client::builder()
-            .user_agent(crate::APP_USER_AGENT)
-            .default_headers(headers)
-            .build()?;
+        let client = make_base_client(authenticated).await?;
 
         let req = client.get(url);
 
@@ -183,12 +184,74 @@ impl FlakeHubClient {
 
         Self::get(url, None, true).await
     }
+
+    async fn metadata(
+        &self,
+        org: &str,
+        project: &str,
+        version: &str,
+    ) -> color_eyre::Result<ProjectMetadata> {
+        let url = flakehub_url!(&self.0, "version", org, project, version);
+        let client = make_base_client(true).await?;
+
+        let res = client.get(&url.to_string()).send().await?;
+
+        if let Err(e) = res.error_for_status_ref() {
+            let err_text = res.text().await?;
+            return Err(e).wrap_err(err_text)?;
+        };
+
+        let res = res.json::<ProjectMetadata>().await?;
+
+        Ok(res)
+    }
+
+    async fn project_and_url(
+        &self,
+        org: &str,
+        project: &str,
+        version: Option<&str>,
+    ) -> color_eyre::Result<(String, url::Url)> {
+        let url = match version {
+            Some(version) => flakehub_url!(&self.0, "version", org, project, version),
+            None => flakehub_url!(&self.0, "f", org, project),
+        };
+        let client = make_base_client(true).await?;
+        let res = client.get(&url.to_string()).send().await?;
+        if let Err(e) = res.error_for_status_ref() {
+            let err_text = res.text().await?;
+            return Err(e).wrap_err(err_text)?;
+        };
+        let res = res.json::<ProjectCanonicalNames>().await?;
+        Ok((res.project, res.pretty_download_url))
+    }
 }
 
 pub(crate) fn print_json<T: Serialize>(value: T) -> Result<(), FhError> {
     let json = serde_json::to_string(&value)?;
     println!("{}", json);
     Ok(())
+}
+
+async fn make_base_client(authenticated: bool) -> Result<Client, FhError> {
+    let mut headers = HeaderMap::new();
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+
+    if authenticated {
+        if let Ok(token) = tokio::fs::read_to_string(auth_token_path()?).await {
+            if !token.is_empty() {
+                headers.insert(
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {}", token.trim()))?,
+                );
+            }
+        }
+    }
+
+    Ok(reqwest::Client::builder()
+        .user_agent(crate::APP_USER_AGENT)
+        .default_headers(headers)
+        .build()?)
 }
 
 #[macro_export]

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -118,10 +118,12 @@ impl FlakeHubClient {
 
         if authenticate {
             if let Ok(token) = tokio::fs::read_to_string(auth_token_path()?).await {
-                headers.insert(
-                    AUTHORIZATION,
-                    HeaderValue::from_str(&format!("Bearer {}", token.trim()))?,
-                );
+                if !token.is_empty() {
+                    headers.insert(
+                        AUTHORIZATION,
+                        HeaderValue::from_str(&format!("Bearer {}", token.trim()))?,
+                    );
+                }
             }
         }
 

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -26,7 +26,7 @@ use self::{
     search::SearchResult,
     status::TokenStatus,
 };
-use crate::flakehub_url;
+use crate::{flakehub_url, APP_USER_AGENT};
 
 #[allow(clippy::type_complexity)]
 static DEFAULT_STYLE: Lazy<
@@ -152,7 +152,8 @@ impl FlakeHubClient {
 
     async fn orgs(api_addr: &str) -> Result<Vec<Org>, FhError> {
         let url = flakehub_url!(api_addr, "orgs");
-        get(url, true).await
+        let params = vec![("include_public", String::from("true"))];
+        get_with_params(url, params, true).await
     }
 
     async fn versions(
@@ -215,7 +216,7 @@ impl FlakeHubClient {
         let url = flakehub_url!(api_addr, "cli", "status");
 
         let res = reqwest::Client::builder()
-            .user_agent(crate::APP_USER_AGENT)
+            .user_agent(APP_USER_AGENT)
             .build()?
             .get(url)
             .header(AUTHORIZATION, &format!("Bearer {token}"))
@@ -276,7 +277,7 @@ async fn make_base_client(_authenticated: bool) -> Result<Client, FhError> {
     headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
     Ok(reqwest::Client::builder()
-        .user_agent(crate::APP_USER_AGENT)
+        .user_agent(APP_USER_AGENT)
         .default_headers(headers)
         .build()?)
 }
@@ -300,7 +301,7 @@ async fn make_base_client(authenticated: bool) -> Result<Client, FhError> {
     }
 
     Ok(reqwest::Client::builder()
-        .user_agent(crate::APP_USER_AGENT)
+        .user_agent(APP_USER_AGENT)
         .default_headers(headers)
         .build()?)
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -132,27 +132,27 @@ impl FlakeHubClient {
     ) -> Result<Vec<SearchResult>, FhError> {
         let url = flakehub_url!(api_addr, "search");
         let params = vec![("q", query)];
-        Self::get_with_params(url, params, false).await
+        get_with_params(url, params, false).await
     }
 
     async fn flakes(api_addr: &str) -> Result<Vec<Flake>, FhError> {
         let url = flakehub_url!(api_addr, "flakes");
-        Self::get(url, true).await
+        get(url, true).await
     }
 
     async fn flakes_by_label(api_addr: &str, label: &str) -> Result<Vec<Flake>, FhError> {
         let url = flakehub_url!(api_addr, "label", label);
-        Self::get(url, true).await
+        get(url, true).await
     }
 
     async fn releases(api_addr: &str, org: &str, project: &str) -> Result<Vec<Release>, FhError> {
         let url = flakehub_url!(api_addr, "f", org, project, "releases");
-        Self::get(url, true).await
+        get(url, true).await
     }
 
     async fn orgs(api_addr: &str) -> Result<Vec<Org>, FhError> {
         let url = flakehub_url!(api_addr, "orgs");
-        Self::get(url, true).await
+        get(url, true).await
     }
 
     async fn versions(
@@ -163,7 +163,7 @@ impl FlakeHubClient {
     ) -> Result<Vec<Version>, FhError> {
         let version = urlencoding::encode(constraint);
         let url = flakehub_url!(api_addr, "version", "resolve", org, project, &version);
-        Self::get(url, true).await
+        get(url, true).await
     }
 
     async fn metadata(
@@ -238,31 +238,28 @@ impl FlakeHubClient {
 
         Ok(token_status)
     }
+}
 
-    async fn get<T: for<'de> Deserialize<'de>>(
-        url: Url,
-        authenticated: bool,
-    ) -> Result<T, FhError> {
-        let client = make_base_client(authenticated).await?;
+async fn get<T: for<'de> Deserialize<'de>>(url: Url, authenticated: bool) -> Result<T, FhError> {
+    let client = make_base_client(authenticated).await?;
 
-        Ok(client.get(url).send().await?.json::<T>().await?)
-    }
+    Ok(client.get(url).send().await?.json::<T>().await?)
+}
 
-    async fn get_with_params<T: for<'de> Deserialize<'de>>(
-        url: Url,
-        params: Vec<(&str, String)>,
-        authenticated: bool,
-    ) -> Result<T, FhError> {
-        let client = make_base_client(authenticated).await?;
+async fn get_with_params<T: for<'de> Deserialize<'de>>(
+    url: Url,
+    params: Vec<(&str, String)>,
+    authenticated: bool,
+) -> Result<T, FhError> {
+    let client = make_base_client(authenticated).await?;
 
-        Ok(client
-            .get(url)
-            .query(&params)
-            .send()
-            .await?
-            .json::<T>()
-            .await?)
-    }
+    Ok(client
+        .get(url)
+        .query(&params)
+        .send()
+        .await?
+        .json::<T>()
+        .await?)
 }
 
 pub(crate) fn print_json<T: Serialize>(value: T) -> Result<(), FhError> {

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -298,3 +298,28 @@ macro_rules! flakehub_url {
         url
     }};
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn flakehub_url_macro() {
+        let root = "https://flakehub.com";
+
+        for (provided, expected) in vec![
+            (
+                flakehub_url!(root, "flake", "DeterminateSystems", "fh"),
+                "https://flakehub.com/flake/DeterminateSystems/fh",
+            ),
+            (
+                flakehub_url!(root, "flake", "NixOS", "nixpkgs", "*"),
+                "https://flakehub.com/flake/NixOS/nixpkgs/*",
+            ),
+            (
+                flakehub_url!(root, "flake", "nix-community", "home-manager", "releases"),
+                "https://flakehub.com/flake/nix-community/home-manager/releases",
+            ),
+        ] {
+            assert_eq!(provided.as_ref(), expected);
+        }
+    }
+}

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -263,6 +263,7 @@ async fn make_base_client(authenticated: bool) -> Result<Client, FhError> {
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
+    #[cfg(not(test))]
     if authenticated {
         if let Ok(token) = tokio::fs::read_to_string(auth_token_path()?).await {
             if !token.is_empty() {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -5,6 +5,8 @@ use std::{io::IsTerminal, process::ExitCode};
 use tabled::{Table, Tabled};
 use url::Url;
 
+use crate::flakehub_url;
+
 use super::{list::FLAKEHUB_WEB_ROOT, print_json, CommandExecute, FlakeHubClient};
 
 /// Searches FlakeHub for flakes that match your query.
@@ -37,16 +39,7 @@ impl SearchResult {
     }
 
     fn url(&self) -> Url {
-        let mut url = Url::parse(FLAKEHUB_WEB_ROOT)
-            .expect("failed to parse flakehub web root url (this should never happen)");
-        {
-            let mut segs = url
-                .path_segments_mut()
-                .expect("flakehub url cannot be base (this should never happen)");
-
-            segs.push("flake").push(&self.org).push(&self.project);
-        }
-        url
+        flakehub_url!(FLAKEHUB_WEB_ROOT, "flake", &self.org, &self.project)
     }
 }
 

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -71,7 +71,7 @@ impl CommandExecute for SearchSubcommand {
         let pb = ProgressBar::new_spinner();
         pb.set_style(ProgressStyle::default_spinner());
 
-        let client = FlakeHubClient::new(&self.api_addr)?;
+        let client = FlakeHubClient::new(&self.api_addr, false).await?;
 
         match client.search(self.query).await {
             Ok(results) => {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -64,7 +64,7 @@ impl CommandExecute for SearchSubcommand {
         let pb = ProgressBar::new_spinner();
         pb.set_style(ProgressStyle::default_spinner());
 
-        let client = FlakeHubClient::new(&self.api_addr, false).await?;
+        let client = FlakeHubClient::new(&self.api_addr);
 
         match client.search(self.query).await {
             Ok(results) => {

--- a/src/cli/cmd/search.rs
+++ b/src/cli/cmd/search.rs
@@ -64,9 +64,7 @@ impl CommandExecute for SearchSubcommand {
         let pb = ProgressBar::new_spinner();
         pb.set_style(ProgressStyle::default_spinner());
 
-        let client = FlakeHubClient::new(&self.api_addr);
-
-        match client.search(self.query).await {
+        match FlakeHubClient::search(self.api_addr.as_ref(), self.query).await {
             Ok(results) => {
                 if results.is_empty() {
                     eprintln!("No results");

--- a/src/cli/cmd/status/mod.rs
+++ b/src/cli/cmd/status/mod.rs
@@ -2,9 +2,8 @@ use std::process::ExitCode;
 
 use clap::Parser;
 use color_eyre::eyre::WrapErr;
-use reqwest::header::AUTHORIZATION;
 
-use super::CommandExecute;
+use super::{CommandExecute, FlakeHubClient};
 
 // TODO: make status and login subcommands of a `auth` subcommand?
 /// Check your FlakeHub token status.
@@ -86,31 +85,5 @@ pub(crate) async fn get_status_from_auth_token(
     api_addr: url::Url,
     token: &str,
 ) -> color_eyre::Result<TokenStatus> {
-    let mut cli_status = api_addr;
-    cli_status.set_path("/cli/status");
-
-    let res = reqwest::Client::builder()
-        .user_agent(crate::APP_USER_AGENT)
-        .build()?
-        .get(cli_status)
-        .header(AUTHORIZATION, &format!("Bearer {token}"))
-        .send()
-        .await
-        .wrap_err("Failed to send request")?;
-
-    if res.status() == 401 {
-        return Err(color_eyre::eyre::eyre!(
-            "The provided token was invalid. Please try again, or contact support@flakehub.com if the problem persists."
-        ));
-    }
-
-    let res = res
-        .error_for_status()
-        .wrap_err("Request was unsuccessful")?;
-    let token_status: TokenStatus = res
-        .json()
-        .await
-        .wrap_err("Failed to get TokenStatus from response (wasn't JSON, or was invalid JSON?)")?;
-
-    Ok(token_status)
+    Ok(FlakeHubClient::auth_status(api_addr.as_ref(), token).await?)
 }

--- a/src/cli/cmd/status/mod.rs
+++ b/src/cli/cmd/status/mod.rs
@@ -78,12 +78,5 @@ pub(crate) async fn get_status_from_auth_file(
         .wrap_err_with(|| format!("Could not open {}", auth_token_path.display()))?;
     let token = token.trim();
 
-    get_status_from_auth_token(api_addr, token).await
-}
-
-pub(crate) async fn get_status_from_auth_token(
-    api_addr: url::Url,
-    token: &str,
-) -> color_eyre::Result<TokenStatus> {
-    Ok(FlakeHubClient::auth_status(api_addr.as_ref(), token).await?)
+    FlakeHubClient::auth_status(api_addr.as_ref(), token).await
 }


### PR DESCRIPTION
This PR changes up the HTTP client for FlakeHub to optionally use authentication for some endpoints.

> [!NOTE]
> This PR also fixes `fh list orgs`, which, I just now found out, is currently broken.