### PR TITLE
Fix FlakeHub URL for flake-compat

### DIFF
--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -207,7 +207,7 @@ impl CommandExecute for InitSubcommand {
                 flake.inputs.insert(
                     String::from("flake-compat"),
                     Input::new(
-                        flakehub_url!(FLAKEHUB_WEB_ROOT, "flake", "edolstra", "flake-compat", "*")
+                        flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "edolstra", "flake-compat", "*")
                             .as_str(),
                         None,
                     ),


### PR DESCRIPTION
This is, of course, not currently a valid flake reference