### PR TITLE
login: require determinate-nixd to login

### DIFF
--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -11,7 +11,6 @@ pub struct DaemonInfoReponse {
 #[derive(Deserialize, Serialize)]
 pub struct NetrcTokenAddRequest {
     pub token: String,
-    pub netrc_lines: String,
 }
 
 pub async fn update_netrc_file(


### PR DESCRIPTION
based on https://github.com/DeterminateSystems/fh/pull/136 branch.

sending this for initial testing with Martin, and consideration of the implications.