### PR TITLE
Split the token into read/write halves. In the read path, optionally …

### DIFF
--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -341,13 +341,13 @@ async fn make_base_client(_authenticated: bool) -> Result<Client, FhError> {
 
 #[cfg(not(test))]
 async fn make_base_client(authenticated: bool) -> Result<Client, FhError> {
-    use self::login::user_auth_token_path;
+    use self::login::user_auth_token_read_path;
 
     let mut headers = HeaderMap::new();
     headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
     if authenticated {
-        if let Ok(token) = tokio::fs::read_to_string(user_auth_token_path()?).await {
+        if let Ok(token) = tokio::fs::read_to_string(user_auth_token_read_path().await?).await {
             if !token.is_empty() {
                 headers.insert(
                     AUTHORIZATION,

--- a/src/cli/cmd/status/mod.rs
+++ b/src/cli/cmd/status/mod.rs
@@ -72,7 +72,7 @@ impl CommandExecute for StatusSubcommand {
 pub(crate) async fn get_status_from_auth_file(
     api_addr: url::Url,
 ) -> color_eyre::Result<TokenStatus> {
-    let auth_token_path = crate::cli::cmd::login::user_auth_token_path()?;
+    let auth_token_path = crate::cli::cmd::login::user_auth_token_read_path().await?;
     let token = tokio::fs::read_to_string(&auth_token_path)
         .await
         .wrap_err_with(|| format!("Could not open {}", auth_token_path.display()))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::cli::{
 const DETERMINATE_STATE_DIR: &str = "/nix/var/determinate";
 const DETERMINATE_NIXD_SOCKET_NAME: &str = "determinate-nixd.socket";
 const DETERMINATE_NIXD_NETRC_NAME: &str = "netrc";
+const DETERMINATE_NIXD_TOKEN_NAME: &str = "token";
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 


### PR DESCRIPTION
…readfrom the global token if possible