### PR TITLE
Do less without dnixd

### DIFF
--- a/src/cli/cmd/login/mod.rs
+++ b/src/cli/cmd/login/mod.rs
@@ -393,6 +393,13 @@ pub async fn upsert_user_nix_config(
         if update_nix_conf {
             let nix_config_contents = tokio::fs::read_to_string(&nix_config_path)
                 .await
+                .or_else(|e| {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        Ok("".to_string())
+                    } else {
+                        Err(e)
+                    }
+                })
                 .wrap_err_with(|| {
                     format!("Reading the Nix configuration file {:?}", &nix_config_path)
                 })?;

--- a/src/cli/cmd/login/mod.rs
+++ b/src/cli/cmd/login/mod.rs
@@ -118,7 +118,9 @@ impl LoginSubcommand {
             Some(
                 tokio::fs::read_to_string(token_file)
                     .await
-                    .wrap_err("Reading the provided token file")?,
+                    .wrap_err("Reading the provided token file")?
+                    .trim()
+                    .to_string(),
             )
         } else {
             println!("Log in to FlakeHub: {}", login_url);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use crate::cli::{
 
 const DETERMINATE_STATE_DIR: &str = "/nix/var/determinate";
 const DETERMINATE_NIXD_SOCKET_NAME: &str = "determinate-nixd.socket";
-const DETERMINATE_NIXD_NETRC_NAME: &str = "netrc";
 const DETERMINATE_NIXD_TOKEN_NAME: &str = "token";
 
 static APP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -11,7 +11,6 @@ pub struct DaemonInfoReponse {
 #[derive(Deserialize, Serialize)]
 pub struct NetrcTokenAddRequest {
     pub token: String,
-    pub netrc_lines: String,
 }
 
 pub async fn update_netrc_file(


### PR DESCRIPTION
Closes #144 

Commit one moves all the "no-dnixd" code into the branch where we don't use it.

Commit two stops writing to the dnixd state directory when dnixd isn't available.