### PR TITLE
Don't create a result symlink when using fh apply

### DIFF
--- a/src/cli/cmd/apply/mod.rs
+++ b/src/cli/cmd/apply/mod.rs
@@ -213,6 +213,9 @@ async fn apply_path_to_profile(
     nix_command(
         &[
             "build",
+            // Don't create a result symlink in the current directory for the profile being installed.
+            // This is verified to not introduce a race condition against an eager garbage collection.
+            "--no-link",
             "--print-build-logs",
             // `--max-jobs 0` ensures that `nix build` doesn't really *build* anything
             // and acts more as a fetch operation


### PR DESCRIPTION
This resolves a problem when a user may attempt to write to /result on macOS in certain circumstances.