### PR TITLE
Improve error output for path resolution

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,12 +8,12 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1725172314,
-        "narHash": "sha256-BtLY9lWu/pe6/ImFwuRRRqMwLacY5AZOKA2hUHUQ64k=",
-        "rev": "28b42d01f549c38bd165296fbcb4fe66d98fc24f",
-        "revCount": 1986,
+        "lastModified": 1727764514,
+        "narHash": "sha256-tvN9v5gTxLI5zOKsNvYl1aUxIitHm8Nj3vKdXNfJo50=",
+        "rev": "a9d2e5fa8d77af05240230c9569bbbddd28ccfaf",
+        "revCount": 2029,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.1986%2Brev-28b42d01f549c38bd165296fbcb4fe66d98fc24f/0191aca7-e3ea-728d-bfd8-c4744f4a108d/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2029%2Brev-a9d2e5fa8d77af05240230c9569bbbddd28ccfaf/01924729-44b5-7df4-a70d-d5e64656e243/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -41,12 +41,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726463316,
-        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
-        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
-        "revCount": 681973,
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "revCount": 696158,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.681973%2Brev-99dc8785f6a0adac95f5e2ab05cc2e1bf666d172/0191fe06-77c6-7f96-9835-e6a8ac5c4059/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.696158%2Brev-2768c7d042a37de65bb1b5b3268fc987e534c49d/0192bd28-d6c0-735c-ab86-8ab9d12f7d62/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1725094379,
-        "narHash": "sha256-TBujPMMIv8RG6BKlsBEpCln1ePmWz79xTcJOQpU2L18=",
+        "lastModified": 1727706011,
+        "narHash": "sha256-xxgUHwwJ+1xQQoUWvLDo807IZ0MDldkfr9N1G4fvNJU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "914a1caab54e48a028b2407d0fe6fade89532f67",
+        "rev": "28830ff2f1158ee92f4852ef3ec35af0935d1562",
         "type": "github"
       },
       "original": {

--- a/src/cli/cmd/apply/mod.rs
+++ b/src/cli/cmd/apply/mod.rs
@@ -83,7 +83,7 @@ impl CommandExecute for ApplySubcommand {
             )?
         };
 
-        tracing::info!("Resolving {}", output_ref);
+        tracing::info!(%output_ref, "Resolving output reference");
 
         let resolved_path =
             FlakeHubClient::resolve(self.api_addr.as_ref(), &output_ref, self.use_scoped_token)

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -1,3 +1,5 @@
+use reqwest::StatusCode;
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum FhError {
     #[error("Nix command `{0}` failed; check prior Nix output for details")]
@@ -33,6 +35,9 @@ pub(crate) enum FhError {
     #[error("malformed flake reference")]
     MalformedFlakeOutputRef,
 
+    #[error("http call returned error code {0}")]
+    MiscHttp(StatusCode),
+
     #[error("{0} is not installed or not on the PATH")]
     MissingExecutable(String),
 
@@ -41,6 +46,12 @@ pub(crate) enum FhError {
 
     #[error("the flake has no inputs")]
     NoInputs,
+
+    #[error("access to this {0} is not authorized")]
+    NotAuthorized(String),
+
+    #[error("{0} {1} not found")]
+    NotFound(String, String),
 
     #[error("template error: {0}")]
     Render(#[from] handlebars::RenderError),


### PR DESCRIPTION
Right now, the error output for path resolution is pretty confusing:

```
Error: 
   0: http error: error decoding response body: invalid type: string "Flake `foo/bar` not found.", expected struct ResolvedPath at line 1 column 47
   1: error decoding response body: invalid type: string "Flake `foo/bar` not found.", expected struct ResolvedPath at line 1 column 47
   2: invalid type: string "Flake `foo/bar` not found.", expected struct ResolvedPath at line 1 column 47
```

This PR makes that error output more granular.