### PR TITLE
Change fh init behavior when executables aren't installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fh"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fh"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Determinate Systems <hello@determinate.systems>"]
 edition = "2021"
 license = "Apache 2.0"

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -240,7 +240,7 @@ impl CommandExecute for InitSubcommand {
             write(self.output, flake_string)?;
 
             if project.has_directory(".git")
-                && command_exists("git")?
+                && command_exists("git")
                 && Prompt::bool(&format!(
                     "Would you like to add your new Nix {} to Git?",
                     if use_flake_compat { "files" } else { "file" }
@@ -263,10 +263,10 @@ impl CommandExecute for InitSubcommand {
                 write(PathBuf::from(".envrc"), String::from("use flake"))?;
 
                 if Prompt::bool("You'll need to run `direnv allow` to activate direnv in this project. Would you like to do that now?") {
-                    if command_exists("direnv")? {
+                    if command_exists("direnv") {
                         Command::new("direnv").arg("allow").output()?;
                     } else {
-                        println!("It looks like direnv isn't installed.");
+                        println!("It looks like direnv isn't installed. Skipping `direnv allow`.");
                     }
                 }
             }
@@ -280,12 +280,8 @@ impl CommandExecute for InitSubcommand {
     }
 }
 
-pub(super) fn command_exists(cmd: &str) -> Result<bool, FhError> {
-    if Command::new(cmd).output().is_err() {
-        return Err(FhError::MissingExecutable(String::from(cmd)));
-    }
-
-    Ok(true)
+pub(super) fn command_exists(cmd: &str) -> bool {
+    Command::new(cmd).output().is_ok()
 }
 
 async fn select_nixpkgs(api_addr: &str) -> Result<Url, FhError> {

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -410,7 +410,9 @@ fn is_root_user() -> bool {
 }
 
 async fn nix_command(args: &[String], sudo_if_necessary: bool) -> Result<(), FhError> {
-    command_exists("nix")?;
+    if !command_exists("nix") {
+        return Err(FhError::MissingExecutable("nix".to_string()));
+    }
 
     let use_sudo = sudo_if_necessary && !is_root_user();
 


### PR DESCRIPTION
This PR changes the behavior of the `command_exists` function to return a Boolean rather than a `Result`. This enables us to handle missing commands a bit more gently.