### PR TITLE
Fix Go version logic in handler

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,12 +8,12 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1727764514,
-        "narHash": "sha256-tvN9v5gTxLI5zOKsNvYl1aUxIitHm8Nj3vKdXNfJo50=",
-        "rev": "a9d2e5fa8d77af05240230c9569bbbddd28ccfaf",
-        "revCount": 2029,
+        "lastModified": 1735713283,
+        "narHash": "sha256-xC6X49L55xo7AV+pAYclOj5UNWtBo/xx5aB5IehJD0M=",
+        "rev": "bfba822a4220b0e2c4dc7f36a35e4c8450cd9a9c",
+        "revCount": 2125,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2029%2Brev-a9d2e5fa8d77af05240230c9569bbbddd28ccfaf/01924729-44b5-7df4-a70d-d5e64656e243/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2125%2Brev-bfba822a4220b0e2c4dc7f36a35e4c8450cd9a9c/019420f1-c64f-7176-bdf5-3f4f4fe2bac6/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -27,12 +27,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1721727458,
-        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
-        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
-        "revCount": 345,
+        "lastModified": 1736429049,
+        "narHash": "sha256-np2K6lbTOq7yugwS0IsEmy+02vxTAF62bp8APnBHsE4=",
+        "rev": "5891bae1b7fbd8d3a138773fd751e7a532f914aa",
+        "revCount": 352,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/naersk/0.1.345%2Brev-3fb418eaf352498f6b6c30592e3beb63df42ef11/0190def5-5fc0-7c65-9b14-61402f53cd47/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/naersk/0.1.352%2Brev-5891bae1b7fbd8d3a138773fd751e7a532f914aa/01944b3d-93aa-7d30-8c2b-bd5902521c73/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -41,12 +41,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732981179,
-        "narHash": "sha256-F7thesZPvAMSwjRu0K8uFshTk3ZZSNAsXTIFvXBT+34=",
-        "rev": "62c435d93bf046a5396f3016472e8f7c8e2aed65",
-        "revCount": 710050,
+        "lastModified": 1736200483,
+        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
+        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
+        "revCount": 712512,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.710050%2Brev-62c435d93bf046a5396f3016472e8f7c8e2aed65/01938188-9ae4-7095-9c6e-c6e2ce4adf18/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.712512%2Brev-3f0a8ac25fb674611b98089ca3a5dd6480175751/01944209-0c88-7bd6-8aac-65b5af418928/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727706011,
-        "narHash": "sha256-xxgUHwwJ+1xQQoUWvLDo807IZ0MDldkfr9N1G4fvNJU=",
+        "lastModified": 1735659655,
+        "narHash": "sha256-DQgwi3pwaasWWDfNtXIX0lW5KvxQ+qVhxO1J7l68Qcc=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "28830ff2f1158ee92f4852ef3ec35af0935d1562",
+        "rev": "085ad107943996c344633d58f26467b05f8e2ff0",
         "type": "github"
       },
       "original": {

--- a/src/cli/cmd/init/handlers/go.rs
+++ b/src/cli/cmd/init/handlers/go.rs
@@ -2,7 +2,7 @@ use crate::cli::cmd::init::prompt::Prompt;
 
 use super::{Flake, Handler, Project};
 
-const GO_VERSIONS: &[&str] = &["1.22"];
+const GO_VERSIONS: &[&str] = &["1.22", "1.23"];
 
 pub(crate) struct Go;
 

--- a/src/cli/cmd/init/handlers/go.rs
+++ b/src/cli/cmd/init/handlers/go.rs
@@ -2,7 +2,7 @@ use crate::cli::cmd::init::prompt::Prompt;
 
 use super::{Flake, Handler, Project};
 
-const GO_VERSIONS: &[&str] = &["20", "19", "18", "17"];
+const GO_VERSIONS: &[&str] = &["1.22"];
 
 pub(crate) struct Go;
 
@@ -10,7 +10,8 @@ impl Handler for Go {
     fn handle(project: &Project, flake: &mut Flake) {
         if project.has_file("go.mod") && Prompt::for_language("Go") {
             let go_version = Prompt::select("Select a version of Go", GO_VERSIONS);
-            flake.dev_shell_packages.push(format!("go_1_{go_version}"));
+            let go_version_attr = format!("go_{}", go_version.replace(".", "_"));
+            flake.dev_shell_packages.push(go_version_attr);
         }
     }
 }

--- a/src/cli/instrumentation.rs
+++ b/src/cli/instrumentation.rs
@@ -43,7 +43,7 @@ pub struct Instrumentation {
     pub log_directives: Vec<Directive>,
 }
 
-impl<'a> Instrumentation {
+impl Instrumentation {
     pub fn log_level(&self) -> String {
         match self.verbose {
             0 => "info",


### PR DESCRIPTION
The current logic misnames Go versions as e.g. 20 instead of 1.20. This fixes that. It also brings the suggested Go version in line with what's currently available in 24.11.