### PR TITLE
Initial implementation of `fh fetch`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,12 +41,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736200483,
-        "narHash": "sha256-JO+lFN2HsCwSLMUWXHeOad6QUxOuwe9UOAF/iSl1J4I=",
-        "rev": "3f0a8ac25fb674611b98089ca3a5dd6480175751",
-        "revCount": 712512,
+        "lastModified": 1739758141,
+        "narHash": "sha256-uq6A2L7o1/tR6VfmYhZWoVAwb3gTy7j4Jx30MIrH0rE=",
+        "rev": "c618e28f70257593de75a7044438efc1c1fc0791",
+        "revCount": 714614,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.712512%2Brev-3f0a8ac25fb674611b98089ca3a5dd6480175751/01944209-0c88-7bd6-8aac-65b5af418928/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.714614%2Brev-c618e28f70257593de75a7044438efc1c1fc0791/0195155d-20df-7b25-ad70-45871483b8d2/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/src/cli/cmd/apply/mod.rs
+++ b/src/cli/cmd/apply/mod.rs
@@ -136,12 +136,8 @@ impl CommandExecute for ApplySubcommand {
 
                     let dir = tempdir()?;
 
-                    let temp_netrc_path = create_temp_netrc(
-                        dir.path(),
-                        self.cache_addr.host_str().expect("valid host"),
-                        &token,
-                    )
-                    .await?;
+                    let temp_netrc_path =
+                        create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
 
                     let display = temp_netrc_path.display().to_string();
                     nix_args.extend_from_slice(&["--netrc-file".to_string(), display]);

--- a/src/cli/cmd/apply/mod.rs
+++ b/src/cli/cmd/apply/mod.rs
@@ -13,7 +13,10 @@ use color_eyre::eyre::Context;
 use tempfile::{tempdir, TempDir};
 
 use crate::{
-    cli::{cmd::nix_command, error::FhError},
+    cli::{
+        cmd::{copy_closure, nix_command},
+        error::FhError,
+    },
     shared::create_temp_netrc,
 };
 
@@ -124,48 +127,14 @@ impl CommandExecute for ApplySubcommand {
         match resolved_path.token {
             Some(token) => {
                 if self.use_scoped_token == TokenChoice::Always {
-                    let mut nix_args = vec![
-                        "copy".to_string(),
-                        "--option".to_string(),
-                        "narinfo-cache-negative-ttl".to_string(),
-                        "0".to_string(),
-                        "--from".to_string(),
-                        self.cache_addr.to_string(),
-                        resolved_path.store_path.clone(),
-                    ];
-
                     let dir = tempdir()?;
 
                     let temp_netrc_path =
                         create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
 
                     let display = temp_netrc_path.display().to_string();
-                    nix_args.extend_from_slice(&["--netrc-file".to_string(), display]);
 
-                    // NOTE(cole-h): Theoretically, this could be garbage collected immediately after we
-                    // copy it. There's no good way to prevent this at this point in time because:
-                    //
-                    // 0. We want to be able to use the scoped token to talk to FlakeHub Cache, which we
-                    // do via `--netrc-file`, and we want to be able to run this on any user -- trusted
-                    // or otherwise
-                    //
-                    // 1. `nix copy` substitutes on the client, so `--netrc-file` works just fine (it
-                    // won't be sent to the daemon, which will say "no" if you're not a trusted user),
-                    // but it doesn't have a `--profile` or `--out-link` argument, so we can't GC
-                    // root it that way
-                    //
-                    // 2. `nix build --max-jobs 0` does have `--profile` and `--out-link`, but passing
-                    // `--netrc-file` will send it to the daemon which doesn't work if you're not a
-                    // trusted user
-                    //
-                    // 3. Manually making a symlink somewhere doesn't work because adding that symlink
-                    // to gcroots/auto requires root, stashing it in a process's environment is so ugly
-                    // I will not entertain it, and holding a handle to it requires it to exist in the
-                    // first place (so there's still a small window of time where it can be GC'd)
-                    //
-                    // This will be resolved when https://github.com/NixOS/nix/pull/11657 makes it into
-                    // a Nix release.
-                    nix_command(&nix_args, false)
+                    copy_closure(self.cache_addr.as_str(), &resolved_path.store_path, display)
                         .await
                         .wrap_err("failed to copy resolved store path with Nix")?;
 

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -1,18 +1,13 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use color_eyre::eyre::{self, WrapErr as _};
+use color_eyre::eyre;
 use color_eyre::Result;
-use tokio::process::Command;
 
-use crate::cli::cmd::nix_command;
+use crate::cli::cmd::copy_closure_with_root;
 use crate::shared::create_temp_netrc;
 
 use super::{CommandExecute, FlakeHubClient};
-
-/// First line of the error message printed by Nix when --out-link isn't
-/// supported. We use this as a feature test to determine which copying we do.
-const OUT_LINK_NOT_SUPPORTED: &[u8] = b"error: unrecognised flag '--out-link'";
 
 #[derive(Parser)]
 pub(crate) struct FetchSubcommand {
@@ -62,138 +57,18 @@ impl CommandExecute for FetchSubcommand {
         let netrc_path = create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
         let token_path = netrc_path.display().to_string();
 
-        copy(
+        copy_closure_with_root(
             self.cache_addr.as_str(),
             &resolved_path.store_path,
             token_path,
-            Some(&self.target),
+            &self.target,
         )
         .await?;
+
+        tracing::info!("Copied {} to {}", resolved_path.store_path, self.target);
 
         dir.close()?;
 
         Ok(ExitCode::SUCCESS)
     }
-}
-
-#[tracing::instrument(skip_all)]
-async fn copy(
-    cache_host: &str,
-    store_path: &str,
-    token_path: String,
-    out: Option<&str>,
-) -> Result<()> {
-    match out {
-        None => copy_without_out_link(cache_host, store_path, token_path).await,
-        Some(out) => {
-            if copy_supports_out_link().await? {
-                copy_with_out_link(cache_host, store_path, token_path, out).await
-            } else {
-                copy_with_nix_realise(cache_host, store_path, token_path, out).await
-            }
-        }
-    }
-}
-
-async fn copy_supports_out_link() -> Result<bool> {
-    // Not using nix_command() here because we need to read the stderr of the resulting command
-    let output = Command::new("nix")
-        .args(["copy", "--out-link"])
-        .output()
-        .await
-        .wrap_err("Could not run nix")?;
-
-    // Grab only the first line of output from nix since it's the one we care about (the problem it encountered)
-    let error_line = output.stderr.split(|&c| c == b'\n').next();
-    let error_line = match error_line {
-        Some(line) => line,
-        None => {
-            tracing::warn!("Could not determine if `nix copy` supports --out-link; falling back to manual links");
-            return Ok(false);
-        }
-    };
-
-    let supported = error_line != OUT_LINK_NOT_SUPPORTED;
-    tracing::debug!(supported, "Setting support for nix copy --out-link");
-
-    Ok(supported)
-}
-
-async fn copy_without_out_link(
-    cache_host: &str,
-    store_path: &str,
-    token_path: String,
-) -> Result<()> {
-    let args = vec![
-        "copy".into(),
-        "--option".into(),
-        "narinfo-cache-negative-ttl".into(),
-        "0".into(),
-        "--from".into(),
-        cache_host.into(),
-        store_path.into(),
-        "--netrc-file".into(),
-        token_path,
-    ];
-
-    nix_command(&args, false)
-        .await
-        .wrap_err("Failed to copy resolved store path with Nix")?;
-
-    tracing::info!("Fetched {store_path}");
-    Ok(())
-}
-
-async fn copy_with_out_link(
-    cache_host: &str,
-    store_path: &str,
-    token_path: String,
-    out: &str,
-) -> Result<()> {
-    let args = vec![
-        "copy".into(),
-        "--option".into(),
-        "narinfo-cache-negative-ttl".into(),
-        "0".into(),
-        "--from".into(),
-        cache_host.into(),
-        store_path.into(),
-        "--out-link".into(),
-        out.into(),
-        "--netrc-file".into(),
-        token_path,
-    ];
-
-    nix_command(&args, false)
-        .await
-        .wrap_err("Failed to copy resolved store path with Nix")?;
-
-    tracing::info!("Fetched {store_path} to {out}");
-    Ok(())
-}
-
-async fn copy_with_nix_realise(
-    cache_host: &str,
-    store_path: &str,
-    token_path: String,
-    out: &str,
-) -> Result<()> {
-    copy_without_out_link(cache_host, store_path, token_path).await?;
-
-    // Now that the flake is on the host machine, we can use a plain `nix-store --realise` on it (but see below)
-    let realise = vec![
-        "nix-store".into(),
-        "realise".into(),
-        store_path.into(),
-        "--add-root".into(),
-        out.into(),
-    ];
-
-    // The most likely scenario for this failing is losing the race between us
-    // trying to create this GC root and some other `nix store gc` run cleaning
-    // it out, so indicate to the user this is out of our hands.
-    nix_command(&realise, false).await.wrap_err_with(|| format!("Could not create a GC root at {out} for {store_path}; consider upgrading to Nix version 2.26 or greater which is immune to this problem"))?;
-
-    tracing::info!("Copied from {store_path} to {out}");
-    Ok(())
 }

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -70,7 +70,7 @@ impl CommandExecute for FetchSubcommand {
         let netrc_path = create_temp_netrc(dir.path(), cache_host, &token).await?;
         let token_path = netrc_path.display().to_string();
 
-        let out_link = self.out_link.as_ref().map(String::as_str);
+        let out_link = self.out_link.as_deref();
 
         copy(
             self.cache_addr.as_str(),

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -62,7 +62,10 @@ impl CommandExecute for FetchSubcommand {
 
         let dir = tempfile::tempdir()?;
 
-        let cache_host = self.cache_addr.host_str().expect("malformed URL: missing host");
+        let cache_host = self
+            .cache_addr
+            .host_str()
+            .expect("malformed URL: missing host");
 
         let netrc_path = create_temp_netrc(dir.path(), cache_host, &token).await?;
         let token_path = netrc_path.display().to_string();

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use color_eyre::eyre;
 use color_eyre::Result;
 
-use crate::cli::cmd::copy_closure_with_root;
+use crate::cli::cmd::copy_closure_with_gc_root;
 use crate::shared::create_temp_netrc;
 
 use super::{CommandExecute, FlakeHubClient};
@@ -57,7 +57,7 @@ impl CommandExecute for FetchSubcommand {
         let netrc_path = create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
         let token_path = netrc_path.display().to_string();
 
-        copy_closure_with_root(
+        copy_closure_with_gc_root(
             self.cache_addr.as_str(),
             &resolved_path.store_path,
             token_path,

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -61,12 +61,7 @@ impl CommandExecute for FetchSubcommand {
 
         let dir = tempfile::tempdir()?;
 
-        let cache_host = self
-            .cache_addr
-            .host_str()
-            .expect("malformed URL: missing host");
-
-        let netrc_path = create_temp_netrc(dir.path(), cache_host, &token).await?;
+        let netrc_path = create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
         let token_path = netrc_path.display().to_string();
 
         let out_link = self.out_link.as_deref();

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -1,0 +1,215 @@
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use clap::Parser;
+use color_eyre::eyre::{self, WrapErr as _};
+use color_eyre::Result;
+use tokio::fs;
+use tokio::process::Command;
+use tokio::{fs::OpenOptions, io::AsyncWriteExt};
+
+use crate::cli::cmd::nix_command;
+
+use super::{CommandExecute, FlakeHubClient};
+
+/// First line of the error message printed by Nix when --out-link isn't
+/// supported. We use this as a feature test to determine which copying we do.
+const OUT_LINK_NOT_SUPPORTED: &[u8] = b"error: unrecognised flag '--out-link'";
+
+#[derive(Parser)]
+pub(crate) struct FetchSubcommand {
+    /// The FlakeHub flake reference to fetch.
+    /// References must be of this form: {org}/{flake}/{version_req}#{attr_path}
+    flake_ref: String,
+
+    /// Output link to store paths in, a la Nix's `--out-link` option.
+    #[clap(long)]
+    out_link: Option<String>,
+
+    #[clap(from_global)]
+    api_addr: url::Url,
+
+    #[clap(from_global)]
+    cache_addr: url::Url,
+
+    #[clap(from_global)]
+    frontend_addr: url::Url,
+}
+
+#[async_trait::async_trait]
+impl CommandExecute for FetchSubcommand {
+    #[tracing::instrument(skip_all)]
+    async fn execute(self) -> Result<ExitCode> {
+        let parsed = super::parse_flake_output_ref(&self.frontend_addr, &self.flake_ref)?;
+
+        let resolved_path = FlakeHubClient::resolve(
+            self.api_addr.as_str(),
+            &parsed,
+            /* use scoped token */ true,
+        )
+        .await?;
+
+        tracing::info!(
+            "Resolved {} to {}",
+            self.flake_ref,
+            resolved_path.store_path
+        );
+
+        let token = match resolved_path.token {
+            Some(token) => token,
+            None => eyre::bail!("Did not receive a scoped token from FlakeHub!"),
+        };
+
+        let dir = tempfile::tempdir()?;
+
+        let cache_host = self.cache_addr.host_str().expect("malformed URL: missing host");
+
+        let netrc_path = create_temp_netrc(dir.path(), cache_host, &token).await?;
+        let token_path = netrc_path.display().to_string();
+
+        let out_link = self.out_link.as_ref().map(String::as_str);
+
+        copy(
+            self.cache_addr.as_str(),
+            &resolved_path.store_path,
+            token_path,
+            out_link,
+        )
+        .await?;
+
+        dir.close()?;
+
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+async fn create_temp_netrc(dir: &Path, host: &str, token: &str) -> Result<PathBuf> {
+    let path = dir.join("netrc");
+
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .mode(0o600)
+        .open(&path)
+        .await?;
+
+    let contents = format!("machine {host} login flakehub password {token}\n");
+
+    file.write_all(contents.as_bytes()).await?;
+
+    Ok(path)
+}
+
+#[tracing::instrument(skip_all)]
+async fn copy(
+    cache_host: &str,
+    store_path: &str,
+    token_path: String,
+    out: Option<&str>,
+) -> Result<()> {
+    match out {
+        None => copy_without_out_link(cache_host, store_path, token_path).await,
+        Some(out) => {
+            if copy_supports_out_link().await? {
+                copy_with_out_link(cache_host, store_path, token_path, out).await
+            } else {
+                copy_with_manual_symlink(cache_host, store_path, token_path, out).await
+            }
+        }
+    }
+}
+
+async fn copy_supports_out_link() -> Result<bool> {
+    // Not using nix_command() here because we need to read the stderr of the resulting command
+    let output = Command::new("nix")
+        .args(["copy", "--out-link"])
+        .output()
+        .await
+        .wrap_err("Could not run nix")?;
+
+    // Grab only the first line of output from nix since it's the one we care about (the problem it encountered)
+    let error_line = output.stderr.split(|&c| c == b'\n').next();
+    let error_line = match error_line {
+        Some(line) => line,
+        None => {
+            tracing::warn!("Could not determine if `nix copy` supports --out-link; falling back to manual links");
+            return Ok(false);
+        }
+    };
+
+    let supported = error_line != OUT_LINK_NOT_SUPPORTED;
+    tracing::debug!(supported, "Setting support for nix copy --out-link");
+
+    Ok(supported)
+}
+
+async fn copy_without_out_link(
+    cache_host: &str,
+    store_path: &str,
+    token_path: String,
+) -> Result<()> {
+    let args = vec![
+        "copy".into(),
+        "--option".into(),
+        "narinfo-cache-negative-ttl".into(),
+        "0".into(),
+        "--from".into(),
+        cache_host.into(),
+        store_path.into(),
+        "--netrc-file".into(),
+        token_path,
+    ];
+
+    nix_command(&args, false)
+        .await
+        .wrap_err("Failed to copy resolved store path with Nix")?;
+
+    tracing::info!("Fetched {store_path}");
+    Ok(())
+}
+
+async fn copy_with_out_link(
+    cache_host: &str,
+    store_path: &str,
+    token_path: String,
+    out: &str,
+) -> Result<()> {
+    let args = vec![
+        "copy".into(),
+        "--option".into(),
+        "narinfo-cache-negative-ttl".into(),
+        "0".into(),
+        "--from".into(),
+        cache_host.into(),
+        store_path.into(),
+        "--out-link".into(),
+        out.into(),
+        "--netrc-file".into(),
+        token_path,
+    ];
+
+    nix_command(&args, false)
+        .await
+        .wrap_err("Failed to copy resolved store path with Nix")?;
+
+    tracing::info!("Fetched {store_path} to {out}");
+    Ok(())
+}
+
+async fn copy_with_manual_symlink(
+    cache_host: &str,
+    store_path: &str,
+    token_path: String,
+    out: &str,
+) -> Result<()> {
+    copy_without_out_link(cache_host, store_path, token_path).await?;
+
+    // TODO: figure out how to make this a GC root
+    fs::symlink(store_path, out)
+        .await
+        .wrap_err_with(|| format!("Could not create symbolic link from {store_path} to {out}"))?;
+
+    tracing::info!("Created manual symbolic link from {store_path} to {out}");
+    Ok(())
+}

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -20,9 +20,8 @@ pub(crate) struct FetchSubcommand {
     /// References must be of this form: {org}/{flake}/{version_req}#{attr_path}
     flake_ref: String,
 
-    /// Output link to store paths in, a la Nix's `--out-link` option.
-    #[clap(long)]
-    out_link: Option<String>,
+    /// Target link to use as a Nix garbage collector root
+    target: String,
 
     #[clap(from_global)]
     api_addr: url::Url,
@@ -63,13 +62,11 @@ impl CommandExecute for FetchSubcommand {
         let netrc_path = create_temp_netrc(dir.path(), &self.cache_addr, &token).await?;
         let token_path = netrc_path.display().to_string();
 
-        let out_link = self.out_link.as_deref();
-
         copy(
             self.cache_addr.as_str(),
             &resolved_path.store_path,
             token_path,
-            out_link,
+            Some(&self.target),
         )
         .await?;
 

--- a/src/cli/cmd/fetch.rs
+++ b/src/cli/cmd/fetch.rs
@@ -1,4 +1,3 @@
-use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::Parser;
@@ -6,9 +5,9 @@ use color_eyre::eyre::{self, WrapErr as _};
 use color_eyre::Result;
 use tokio::fs;
 use tokio::process::Command;
-use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 
 use crate::cli::cmd::nix_command;
+use crate::shared::create_temp_netrc;
 
 use super::{CommandExecute, FlakeHubClient};
 
@@ -84,24 +83,6 @@ impl CommandExecute for FetchSubcommand {
 
         Ok(ExitCode::SUCCESS)
     }
-}
-
-async fn create_temp_netrc(dir: &Path, host: &str, token: &str) -> Result<PathBuf> {
-    let path = dir.join("netrc");
-
-    let mut file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .mode(0o600)
-        .open(&path)
-        .await?;
-
-    let contents = format!("machine {host} login flakehub password {token}\n");
-
-    file.write_all(contents.as_bytes()).await?;
-
-    Ok(path)
 }
 
 #[tracing::instrument(skip_all)]

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod apply;
 pub(crate) mod completion;
 pub(crate) mod convert;
 pub(crate) mod eject;
+pub(crate) mod fetch;
 pub(crate) mod init;
 pub(crate) mod list;
 pub(crate) mod login;
@@ -69,6 +70,7 @@ pub(crate) enum FhSubcommands {
     Completion(completion::CompletionSubcommand),
     Convert(convert::ConvertSubcommand),
     Eject(eject::EjectSubcommand),
+    Fetch(fetch::FetchSubcommand),
     Init(init::InitSubcommand),
     List(list::ListSubcommand),
     Login(login::LoginSubcommand),

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -24,6 +24,7 @@ use tabled::settings::{
     style::{HorizontalLine, On, VerticalLineIter},
     Style,
 };
+use tokio::process::Command;
 use url::Url;
 
 use self::{
@@ -519,4 +520,132 @@ mod tests {
             assert_eq!(provided.as_ref(), expected);
         }
     }
+}
+
+
+/// Copy a Nix closure from a given host into the store.
+pub async fn copy_closure(
+    cache_host: impl Into<String>,
+    store_path: impl Into<String>,
+    token_path: impl Into<String>,
+) -> color_eyre::Result<()> {
+    let args = vec![
+        "copy".into(),
+        "--option".into(),
+        "narinfo-cache-negative-ttl".into(),
+        "0".into(),
+        "--from".into(),
+        cache_host.into(),
+        store_path.into(),
+        "--netrc-file".into(),
+        token_path.into(),
+    ];
+
+    nix_command(&args, false)
+        .await
+        .wrap_err("Failed to copy resolved store path with Nix")?;
+
+    Ok(())
+}
+
+async fn copy_supports_out_link() -> color_eyre::Result<bool> {
+    const OUT_LINK_NOT_SUPPORTED: &[u8] = b"error: unrecognised flag '--out-link'";
+
+    // Not using nix_command() here because we need to read the stderr of the resulting command
+    let output = Command::new("nix")
+        .args(["copy", "--out-link"])
+        .output()
+        .await
+        .wrap_err("Could not run nix")?;
+
+    // Grab only the first line of output from nix since it's the one we care about (the problem it encountered)
+    let error_line = output.stderr.split(|&c| c == b'\n').next();
+    let error_line = match error_line {
+        Some(line) => line,
+        None => {
+            tracing::warn!("Could not determine if `nix copy` supports --out-link; falling back to manual links");
+            return Ok(false);
+        }
+    };
+
+    let supported = error_line != OUT_LINK_NOT_SUPPORTED;
+    tracing::debug!(supported, "Setting support for nix copy --out-link");
+
+    Ok(supported)
+}
+
+async fn copy_closure_with_out_link(
+    cache_host: impl Into<String>,
+    store_path: impl Into<String>,
+    token_path: impl Into<String>,
+    out_path: impl Into<String>,
+) -> color_eyre::Result<()> {
+    let args = vec![
+        "copy".into(),
+        "--option".into(),
+        "narinfo-cache-negative-ttl".into(),
+        "0".into(),
+        "--from".into(),
+        cache_host.into(),
+        store_path.into(),
+        "--out-link".into(),
+        out_path.into(),
+        "--netrc-file".into(),
+        token_path.into(),
+    ];
+
+    nix_command(&args, false)
+        .await
+        .wrap_err("Failed to copy resolved store path with Nix")
+}
+
+async fn copy_closure_with_realise(
+    cache_host: impl Into<String>,
+    store_path: impl Into<String>,
+    token_path: impl Into<String>,
+    out_path: impl Into<String>,
+) -> color_eyre::Result<()> {
+    let cache_host = cache_host.into();
+    let store_path = store_path.into();
+    let token_path = token_path.into();
+    let out_path = out_path.into();
+
+    // First, copy the closure down into the user's Nix store
+    copy_closure(cache_host, &store_path, &token_path).await?;
+
+    // Now we can use a plain `nix-store --realise` on it (but see below)
+    let realise = vec![
+        "nix-store".into(),
+        "realise".into(),
+        store_path.clone(),
+        "--add-root".into(),
+        out_path.clone(),
+    ];
+
+    // The most likely scenario for this failing is losing the race between us
+    // trying to create this GC root and some other `nix store gc` run cleaning
+    // it out, so indicate to the user this is out of our hands.
+    nix_command(&realise, false).await.wrap_err_with(|| format!("Could not create a GC root at {out_path} for {store_path}; consider upgrading to Nix version 2.26 or greater which is immune to this problem"))?;
+
+    Ok(())
+}
+
+/// Copy a Nix closure like [`copy_closure`], but with a GC root. The bool that
+/// is returned indicates if `nix copy --out-link` (supported with version 2.26)
+/// was used.
+pub async fn copy_closure_with_root(
+    cache_host: impl Into<String>,
+    store_path: impl Into<String>,
+    token_path: impl Into<String>,
+    out_path: impl Into<String>,
+) -> color_eyre::Result<bool> {
+    let use_out_link = copy_supports_out_link().await?;
+
+    if use_out_link {
+        copy_closure_with_out_link(cache_host, store_path, token_path, out_path).await?;
+    } else {
+        copy_closure_with_realise(cache_host, store_path, token_path, out_path).await?;
+    }
+
+    Ok(use_out_link)
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -522,7 +522,6 @@ mod tests {
     }
 }
 
-
 /// Copy a Nix closure from a given host into the store.
 pub async fn copy_closure(
     cache_host: impl Into<String>,

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -497,31 +497,6 @@ fn validate_segment(s: &str) -> Result<(), FhError> {
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn flakehub_url_macro() {
-        let root = "https://flakehub.com";
-
-        for (provided, expected) in vec![
-            (
-                flakehub_url!(root, "flake", "DeterminateSystems", "fh"),
-                "https://flakehub.com/flake/DeterminateSystems/fh",
-            ),
-            (
-                flakehub_url!(root, "flake", "NixOS", "nixpkgs", "*"),
-                "https://flakehub.com/flake/NixOS/nixpkgs/*",
-            ),
-            (
-                flakehub_url!(root, "flake", "nix-community", "home-manager", "releases"),
-                "https://flakehub.com/flake/nix-community/home-manager/releases",
-            ),
-        ] {
-            assert_eq!(provided.as_ref(), expected);
-        }
-    }
-}
-
 /// Copy a Nix closure from a given host into the store.
 pub async fn copy_closure(
     cache_host: impl Into<String>,
@@ -650,4 +625,29 @@ pub async fn copy_closure_with_gc_root(
     }
 
     Ok(use_out_link)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn flakehub_url_macro() {
+        let root = "https://flakehub.com";
+
+        for (provided, expected) in vec![
+            (
+                flakehub_url!(root, "flake", "DeterminateSystems", "fh"),
+                "https://flakehub.com/flake/DeterminateSystems/fh",
+            ),
+            (
+                flakehub_url!(root, "flake", "NixOS", "nixpkgs", "*"),
+                "https://flakehub.com/flake/NixOS/nixpkgs/*",
+            ),
+            (
+                flakehub_url!(root, "flake", "nix-community", "home-manager", "releases"),
+                "https://flakehub.com/flake/nix-community/home-manager/releases",
+            ),
+        ] {
+            assert_eq!(provided.as_ref(), expected);
+        }
+    }
 }

--- a/src/cli/cmd/mod.rs
+++ b/src/cli/cmd/mod.rs
@@ -633,7 +633,7 @@ async fn copy_closure_with_realise(
 /// Copy a Nix closure like [`copy_closure`], but with a GC root. The bool that
 /// is returned indicates if `nix copy --out-link` (supported with version 2.26)
 /// was used.
-pub async fn copy_closure_with_root(
+pub async fn copy_closure_with_gc_root(
     cache_host: impl Into<String>,
     store_path: impl Into<String>,
     token_path: impl Into<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ async fn main() -> color_eyre::Result<std::process::ExitCode> {
         FhSubcommands::Completion(completion) => completion.execute().await,
         FhSubcommands::Convert(convert) => convert.execute().await,
         FhSubcommands::Eject(eject) => eject.execute().await,
+        FhSubcommands::Fetch(fetch) => fetch.execute().await,
         FhSubcommands::Init(init) => init.execute().await,
         FhSubcommands::List(list) => list.execute().await,
         FhSubcommands::Login(login) => login.execute().await,

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -4,6 +4,7 @@ use color_eyre::eyre::Context as _;
 use serde::{Deserialize, Serialize};
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
+use url::Url;
 
 #[derive(Deserialize, Serialize)]
 pub struct DaemonInfoReponse {
@@ -184,7 +185,13 @@ pub fn merge_nix_configs(
         .to_owned()
 }
 
-pub async fn create_temp_netrc(dir: &Path, host: &str, token: &str) -> color_eyre::Result<PathBuf> {
+pub async fn create_temp_netrc(
+    dir: &Path,
+    host_url: &Url,
+    token: &str,
+) -> color_eyre::Result<PathBuf> {
+    let host = host_url.host_str().expect("Malformed URL: missing host");
+
     let path = dir.join("netrc");
 
     let mut file = OpenOptions::new()


### PR DESCRIPTION
This PR is an initial implementation of `fh fetch`. Users can request an out link with `--out-link`. This is supported natively in nix 2.26, so on lower versions we manually create a symbolic link.