### PR TITLE
Remove use-flakehub param in CI

### DIFF
--- a/.github/workflows/flakehub-cache.yml
+++ b/.github/workflows/flakehub-cache.yml
@@ -19,8 +19,6 @@ jobs:
             runner: macos-latest-xlarge
           - nix-system: x86_64-linux
             runner: UbuntuLatest32Cores128G
-          - nix-system: aarch64-linux
-            runner: UbuntuLatest32Cores128GArm
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/flakehub-cache.yml
+++ b/.github/workflows/flakehub-cache.yml
@@ -8,17 +8,19 @@ jobs:
   push-dev-shell-to-flakehub-cache:
     runs-on: ${{ matrix.systems.runner }}
     permissions:
-      id-token: "write"
-      contents: "read"
+      id-token: write
+      contents: read
     strategy:
       matrix:
         systems:
-          - nix-system: "aarch64-darwin"
-            runner: "macos-latest-xlarge"
-          - nix-system: "x86_64-darwin"
-            runner: "macos-latest-xlarge"
-          - nix-system: "x86_64-linux"
-            runner: "ubuntu-22.04"
+          - nix-system: aarch64-darwin
+            runner: macos-latest-xlarge
+          - nix-system: x86_64-darwin
+            runner: macos-latest-xlarge
+          - nix-system: x86_64-linux
+            runner: UbuntuLatest32Cores128G
+          - nix-system: aarch64-linux
+            runner: UbuntuLatest32Cores128GArm
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/flakehub-cache.yml
+++ b/.github/workflows/flakehub-cache.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
-        with:
-          use-flakehub: true
       - name: Build dev shell for ${{ matrix.systems.nix-system }} on ${{ matrix.systems.runner }}
         run: |
           nix build .#devShells.${{ matrix.systems.nix-system }}.default


### PR DESCRIPTION
Part of a general effort to ensure that we use our own tools properly in our own repos.
