### PR TITLE
Remove legacyPackages output

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,8 +82,6 @@
             ]);
         };
 
-      legacyPackages = forAllSystems ({ system, pkgs }: pkgs);
-
       packages = forAllSystems ({ system, pkgs }: rec {
         inherit (pkgs) fh;
         default = pkgs.fh;


### PR DESCRIPTION
This was added potentially by mistake in #194 but only makes sense in flakes with many package outputs, such as Nixpkgs.
