### PR TITLE
Strip .tar.gz from fh add flake references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fh"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fh"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["Determinate Systems <hello@determinate.systems>"]
 edition = "2021"
 license = "Apache 2.0"

--- a/src/cli/cmd/add/mod.rs
+++ b/src/cli/cmd/add/mod.rs
@@ -158,8 +158,13 @@ async fn infer_flake_input_name_url(
                 ))?,
             };
 
-            let (flakehub_input, url) =
+            let (flakehub_input, mut url) =
                 get_flakehub_project_and_url(&api_addr, org, project, version).await?;
+
+            if let Some(path_without_suffix) = url.path().strip_suffix(".tar.gz") {
+                let owned_path = path_without_suffix.to_string();
+                url.set_path(&owned_path);
+            }
 
             if let Some(input_name) = input_name {
                 Ok((input_name, url))

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -255,12 +255,11 @@ async fn select_nixpkgs(api_addr: &str) -> Result<Url, FhError> {
     let releases = FlakeHubClient::releases(api_addr, "NixOS", "nixpkgs", None).await?;
     let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
     let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);
-    let version = format!("{release}.tar.gz");
     Ok(flakehub_url!(
         FLAKEHUB_WEB_ROOT,
         "f",
         "NixOS",
         "nixpkgs",
-        &version
+        &release
     ))
 }


### PR DESCRIPTION
As it stands, `fh add` writes flake references like this to your flake:

```nix
{
  nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/nixpkgs-weekly/0.1.884554.tar.gz";
}
```

The `.tar.gz` is no longer necessary and is a less-good vibe than not having it, so this PR strips it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL suffix handling in the add command for consistent package source processing
  * Improved release version handling during initialization for cleaner path construction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->