### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/actions/download-persist.yaml
+++ b/.github/actions/download-persist.yaml
@@ -9,10 +9,10 @@ inputs:
     required: true
   os:
     type: choice
-    required: true
     options:
       - Linux
       - macOS
+    required: true
 
 runs:
   using: composite

--- a/.github/actions/download-persist.yaml
+++ b/.github/actions/download-persist.yaml
@@ -1,0 +1,25 @@
+name: Download and persist artifact
+
+inputs:
+  arch:
+    type: choice
+    options:
+      - X64
+      - ARM64
+    required: true
+  os:
+    type: choice
+    required: true
+    options:
+      - linux
+      - macOS
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v6
+      with:
+        name: flake-checker-${{ inputs.arch }}-${{ inputs.os }}
+        path: cache-binary-${{ inputs.arch }}-${{ inputs.os }}
+    - shell: bash
+      run: cp ./cache-binary-${{ inputs.arch }}-${{ inputs.os }}/flake-checker ./artifacts/${{ inputs.arch }}-${{ inputs.os }}

--- a/.github/actions/download-persist.yaml
+++ b/.github/actions/download-persist.yaml
@@ -19,7 +19,7 @@ runs:
   steps:
     - uses: actions/download-artifact@v6
       with:
-        name: flake-checker-${{ inputs.arch }}-${{ inputs.os }}
+        name: fh-${{ inputs.arch }}-${{ inputs.os }}
         path: cache-binary-${{ inputs.arch }}-${{ inputs.os }}
     - shell: bash
-      run: cp ./cache-binary-${{ inputs.arch }}-${{ inputs.os }}/flake-checker ./artifacts/${{ inputs.arch }}-${{ inputs.os }}
+      run: cp ./cache-binary-${{ inputs.arch }}-${{ inputs.os }}/fh ./artifacts/${{ inputs.arch }}-${{ inputs.os }}

--- a/.github/actions/download-persist.yaml
+++ b/.github/actions/download-persist.yaml
@@ -11,7 +11,7 @@ inputs:
     type: choice
     required: true
     options:
-      - linux
+      - Linux
       - macOS
 
 runs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,12 @@ jobs:
           - nix-system: "aarch64-darwin"
             runner: "macos-latest-xlarge"
             artifact: "fh-ARM64-macOS"
-          - nix-system: "aarch64-linux"
+          - nix-system: "aarch64-Linux"
             runner: "namespace-profile-default-arm64"
             artifact: "fh-X64-Linux"
-          - nix-system: "x86_64-linux"
-            runner: "ubuntu-22.04"
-            artifact: "fh-ARM64-linux"
+          - nix-system: "x86_64-Linux"
+            runner: "ubuntu-24.04"
+            artifact: "fh-ARM64-Linux"
     steps:
       - name: git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
           - nix-system: "aarch64-darwin"
             runner: "macos-latest-xlarge"
             artifact: "fh-ARM64-macOS"
-          - nix-system: "aarch64-Linux"
+          - nix-system: "aarch64-linux"
             runner: "namespace-profile-default-arm64"
             artifact: "fh-X64-Linux"
-          - nix-system: "x86_64-Linux"
+          - nix-system: "x86_64-linux"
             runner: "ubuntu-24.04"
             artifact: "fh-ARM64-Linux"
     steps:

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -13,7 +13,6 @@ jobs:
 
   release:
     needs: build
-
     concurrency: release
     runs-on: ubuntu-latest
     permissions:
@@ -26,19 +25,29 @@ jobs:
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts
 
+      # aarch64-darwin
       - uses: actions/download-artifact@v4
         with:
-          name: fh-X64-macOS
-          path: cache-binary-X64-macOS
+          name: fh-ARM64-macOS
+          path: cache-binary-ARM64-macOS
       - name: Persist the cache binary
-        run: cp ./cache-binary-X64-macOS/fh ./artifacts/X64-macOS
+        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
 
+      # x86_64-linux
       - uses: actions/download-artifact@v4
         with:
           name: fh-X64-Linux
           path: cache-binary-X64-Linux
       - name: Persist the cache binary
         run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+
+      # aarch64-linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: fh-ARM64-Linux
+          path: cache-binary-ARM64-Linux
+      - name: Persist the cache binary
+        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -26,19 +26,19 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: macOS
 
       # x86_64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: X64
           os: Linux
 
       # aarch64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: Linux

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -26,28 +26,22 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-macOS
-          path: cache-binary-ARM64-macOS
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
+          arch: ARM64
+          os: macOS
 
       # x86_64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-X64-Linux
-          path: cache-binary-X64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+          arch: X64
+          os: Linux
 
       # aarch64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-Linux
-          path: cache-binary-ARM64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
+          arch: ARM64
+          os: Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -36,19 +36,19 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: macOS
 
       # x86_64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: X64
           os: Linux
 
       # aarch64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: Linux

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -35,19 +35,29 @@ jobs:
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts
 
+      # aarch64-darwin
       - uses: actions/download-artifact@v4
         with:
-          name: fh-X64-macOS
-          path: cache-binary-X64-macOS
+          name: fh-ARM64-macOS
+          path: cache-binary-ARM64-macOS
       - name: Persist the cache binary
-        run: cp ./cache-binary-X64-macOS/fh ./artifacts/X64-macOS
+        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
 
+      # x86_64-linux
       - uses: actions/download-artifact@v4
         with:
           name: fh-X64-Linux
           path: cache-binary-X64-Linux
       - name: Persist the cache binary
         run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+
+      # aarch64-linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: fh-ARM64-Linux
+          path: cache-binary-ARM64-Linux
+      - name: Persist the cache binary
+        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -36,28 +36,22 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-macOS
-          path: cache-binary-ARM64-macOS
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
+          arch: ARM64
+          os: macOS
 
       # x86_64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-X64-Linux
-          path: cache-binary-X64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+          arch: X64
+          os: Linux
 
       # aarch64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-Linux
-          path: cache-binary-ARM64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
+          arch: ARM64
+          os: Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -25,28 +25,22 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-macOS
-          path: cache-binary-ARM64-macOS
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
+          arch: ARM64
+          os: macOS
 
       # x86_64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-X64-Linux
-          path: cache-binary-X64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+          arch: X64
+          os: Linux
 
       # aarch64-linux
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-artifact
         with:
-          name: fh-ARM64-Linux
-          path: cache-binary-ARM64-Linux
-      - name: Persist the cache binary
-        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
+          arch: ARM64
+          os: Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -52,8 +52,9 @@ jobs:
 
       - name: Rename binaries for GH release
         run: |
-          mv ./artifacts/{,fh-}X64-macOS
           mv ./artifacts/{,fh-}X64-Linux
+          mv ./artifacts/{,fh-}ARM64-macOS
+          mv ./artifacts/{,fh-}ARM64-Linux
 
       - name: Publish Release to GitHub (Tag)
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -25,19 +25,19 @@ jobs:
         run: rm -rf ./artifacts && mkdir ./artifacts
 
       # aarch64-darwin
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: macOS
 
       # x86_64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: X64
           os: Linux
 
       # aarch64-linux
-      - uses: ./.github/actions/download-artifact
+      - uses: ./.github/actions/download-persist
         with:
           arch: ARM64
           os: Linux

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -24,21 +24,29 @@ jobs:
       - name: Create the artifacts directory
         run: rm -rf ./artifacts && mkdir ./artifacts
 
+      # aarch64-darwin
       - uses: actions/download-artifact@v4
         with:
-          name: fh-X64-macOS
-          path: cache-binary-X64-macOS
-
+          name: fh-ARM64-macOS
+          path: cache-binary-ARM64-macOS
       - name: Persist the cache binary
-        run: cp ./cache-binary-X64-macOS/fh ./artifacts/X64-macOS
+        run: cp ./cache-binary-ARM64-macOS/fh ./artifacts/ARM64-macOS
 
+      # x86_64-linux
       - uses: actions/download-artifact@v4
         with:
           name: fh-X64-Linux
           path: cache-binary-X64-Linux
-
       - name: Persist the cache binary
         run: cp ./cache-binary-X64-Linux/fh ./artifacts/X64-Linux
+
+      # aarch64-linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: fh-ARM64-Linux
+          path: cache-binary-ARM64-Linux
+      - name: Persist the cache binary
+        run: cp ./cache-binary-ARM64-Linux/fh ./artifacts/ARM64-Linux
 
       - uses: DeterminateSystems/push-artifact-ids@main
         with:


### PR DESCRIPTION
By mistake, releases have thus far only included `x86_64-darwin` and `x86_64-linux`. This updates the release to include `aarch64-darwin`, `x86_64-linux`, and `aarch64-linux` (i.e. our company-wide supported systems).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized artifact download and persistence across release and PR pipelines, ensuring artifacts are placed into a consistent artifacts directory.
  * Added explicit ARM64 support alongside X64 for macOS and Linux release and PR workflows.
  * Updated build matrix and artifact naming for clearer, consistent release outputs and platform alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->