### PR TITLE
Adds Ruby 4.0 to init ruby handlers

### DIFF
--- a/src/cli/cmd/init/handlers/ruby.rs
+++ b/src/cli/cmd/init/handlers/ruby.rs
@@ -2,7 +2,7 @@ use crate::cli::cmd::init::{project::Project, prompt::Prompt};
 
 use super::{Flake, Handler, version_as_attr};
 
-const RUBY_VERSIONS: &[&str] = &["3.2", "3.1"];
+const RUBY_VERSIONS: &[&str] = &["4.0", "3.2", "3.1"];
 
 pub(crate) struct Ruby;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ruby 4.0 as a selectable version option during project initialization, alongside existing Ruby 3.2 and 3.1 versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->