### PR TITLE
Use standard Nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769555363,
-        "narHash": "sha256-iAtXedOlywGRQNyrd3dRNNAJYg8JMzL/i0938n1884A=",
-        "rev": "d8354b80853fa64bd951ddf9295ea2cc0ee970fc",
-        "revCount": 438,
+        "lastModified": 1774106199,
+        "narHash": "sha256-US5Tda2sKmjrg2lNHQL3jRQ6p96cgfWh3J1QBliQ8Ws=",
+        "rev": "6c9a78c09ff4d6c21d0319114873508a6ec01655",
+        "revCount": 967235,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/secure/0.927018.438/019c01ba-90fc-73f5-a172-76cde28ed3d8/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.967235%2Brev-6c9a78c09ff4d6c21d0319114873508a6ec01655/019d198c-70dc-7753-b1d1-721451f578ae/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/secure/0"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The official CLI for FlakeHub: search for flakes, and add new inputs to your Nix flake.";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/DeterminateSystems/secure/0";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
 
     fenix = {
       url = "https://flakehub.com/f/nix-community/fenix/0.1";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream package source configuration, switching to NixOS nixpkgs as the primary package provider for the project environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->