### PR TITLE
Re-work Nixpkgs selection in init command

### DIFF
--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -81,10 +81,7 @@ impl CommandExecute for InitSubcommand {
             // so best to just include it in all flakes.
             let nixpkgs_version = match Prompt::select(
                 "Which Nixpkgs version would you like to include?",
-                &[
-                    NIXPKGS_STABLE,
-                    NIXPKGS_UNSTABLE,
-                ],
+                &[NIXPKGS_STABLE, NIXPKGS_UNSTABLE],
             )
             .as_str()
             {
@@ -252,4 +249,3 @@ impl CommandExecute for InitSubcommand {
 pub(super) fn command_exists(cmd: &str) -> bool {
     Command::new(cmd).output().is_ok()
 }
-

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -13,7 +13,6 @@ use std::{
     path::PathBuf,
     process::{Command, ExitCode, exit},
 };
-use url::Url;
 
 use crate::{
     cli::{
@@ -22,8 +21,6 @@ use crate::{
     },
     flakehub_url,
 };
-
-use super::FlakeHubClient;
 
 use self::{
     dev_shell::DevShell,
@@ -40,7 +37,6 @@ use super::CommandExecute;
 // Nixpkgs references
 const NIXPKGS_STABLE: &str = "stable";
 const NIXPKGS_UNSTABLE: &str = "unstable";
-const NIXPKGS_SPECIFIC: &str = "select a specific release (not recommended in most cases)";
 
 /// Create a new flake.nix using an opinionated interactive initializer.
 #[derive(Parser)]
@@ -88,7 +84,6 @@ impl CommandExecute for InitSubcommand {
                 &[
                     NIXPKGS_STABLE,
                     NIXPKGS_UNSTABLE,
-                    NIXPKGS_SPECIFIC,
                 ],
             )
             .as_str()
@@ -98,7 +93,6 @@ impl CommandExecute for InitSubcommand {
                 NIXPKGS_UNSTABLE => {
                     flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.1")
                 }
-                NIXPKGS_SPECIFIC => select_nixpkgs(self.api_addr.as_ref()).await?,
                 // Just in case
                 _ => return Err(FhError::Unreachable(String::from("nixpkgs selection")).into()),
             };
@@ -259,15 +253,3 @@ pub(super) fn command_exists(cmd: &str) -> bool {
     Command::new(cmd).output().is_ok()
 }
 
-async fn select_nixpkgs(api_addr: &str) -> Result<Url, FhError> {
-    let releases = FlakeHubClient::releases(api_addr, "NixOS", "nixpkgs", None).await?;
-    let releases: Vec<&str> = releases.iter().map(|r| r.version.as_str()).collect();
-    let release = Prompt::select("Choose one of the following Nixpkgs releases:", &releases);
-    Ok(flakehub_url!(
-        FLAKEHUB_WEB_ROOT,
-        "f",
-        "NixOS",
-        "nixpkgs",
-        &release
-    ))
-}

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -38,8 +38,7 @@ use self::{
 use super::CommandExecute;
 
 // Nixpkgs references
-const NIXPKGS_LATEST: &str = "latest stable (currently 24.11)";
-const NIXPKGS_24_11: &str = "24.11";
+const NIXPKGS_STABLE: &str = "stable";
 const NIXPKGS_UNSTABLE: &str = "unstable";
 const NIXPKGS_SPECIFIC: &str = "select a specific release (not recommended in most cases)";
 
@@ -87,8 +86,7 @@ impl CommandExecute for InitSubcommand {
             let nixpkgs_version = match Prompt::select(
                 "Which Nixpkgs version would you like to include?",
                 &[
-                    NIXPKGS_LATEST,
-                    NIXPKGS_24_11,
+                    NIXPKGS_STABLE,
                     NIXPKGS_UNSTABLE,
                     NIXPKGS_SPECIFIC,
                 ],
@@ -96,12 +94,9 @@ impl CommandExecute for InitSubcommand {
             .as_str()
             {
                 // MAYBE: find an enum-based approach to this
-                NIXPKGS_LATEST => flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "*"),
-                NIXPKGS_24_11 => {
-                    flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.2411.*")
-                }
+                NIXPKGS_STABLE => flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0"),
                 NIXPKGS_UNSTABLE => {
-                    flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.1.*")
+                    flakehub_url!(FLAKEHUB_WEB_ROOT, "f", "NixOS", "nixpkgs", "0.1")
                 }
                 NIXPKGS_SPECIFIC => select_nixpkgs(self.api_addr.as_ref()).await?,
                 // Just in case


### PR DESCRIPTION
This updates the Nixpkgs selector in the `fh init` command to only provide stable (`0`) or unstable (`0.1`). This makes the command less brittle, as we don't need to provide 25.11, 26.05, etc in the selector, and it removes the option to pin to a specific Nixpkgs revision, which I doubt anyone has used.

Fixes #217 

## Summary by CodeRabbit

* **Improvements**
  * Simplified the initialization setup interface by consolidating multiple stable release options into a single "stable" choice, reducing user decision complexity and streamlining the configuration experience
  * Enhanced package source resolution capabilities for both stable and unstable versions with refined versioning patterns to ensure consistent, predictable, and more reliable behavior across releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified initializer options by consolidating multiple stable choices into a single "stable" selection to reduce decision steps.
  * Standardized mapping for stable and unstable sources so version resolution is more predictable.
  * Removed the dynamic release-selection flow so initial setup is faster and more deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->