### PR TITLE
Switch Nix formatter supplied by init command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fh"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fh"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["Determinate Systems <hello@determinate.systems>"]
 edition = "2024"
 license = "Apache 2.0"

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -145,9 +145,9 @@ impl CommandExecute for InitSubcommand {
 
             // Nix formatter
             if Prompt::bool(
-                "Would you like to add our recommended Nix formatter (nixpkgs-fmt) to your environment?",
+                "Would you like to add the official Nix formatter (nixfmt) to your environment?",
             ) {
-                flake.dev_shell_packages.push(String::from("nixpkgs-fmt"));
+                flake.dev_shell_packages.push(String::from("nixfmt"));
             }
 
             flake.doc_comments = Prompt::bool(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default Nix formatter recommendation in the interactive initializer to use the official formatter instead of an unofficial alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->