### PR TITLE
Remove flake schemas from init command flake

### DIFF
--- a/src/assets/flake.hbs
+++ b/src/assets/flake.hbs
@@ -50,9 +50,6 @@
         pkgs = import nixpkgs { inherit {{#if has_overlays }}overlays {{/if}}system; };
       });
     in {
-      {{#if @root.doc_comments}}# Schemas tell Nix about the structure of your flake's outputs{{/if}}
-      schemas = flake-schemas.schemas;
-
       {{#with dev_shells as |dev_shells|}}
       {{#if @root.doc_comments}}# Development environments{{/if}}
       devShells = forEachSupportedSystem ({ pkgs }: {

--- a/src/cli/cmd/init/mod.rs
+++ b/src/cli/cmd/init/mod.rs
@@ -113,21 +113,6 @@ impl CommandExecute for InitSubcommand {
                 Input::new(nixpkgs_version.as_ref(), None),
             );
 
-            flake.inputs.insert(
-                String::from("flake-schemas"),
-                Input::new(
-                    flakehub_url!(
-                        FLAKEHUB_WEB_ROOT,
-                        "f",
-                        "DeterminateSystems",
-                        "flake-schemas",
-                        "*"
-                    )
-                    .as_str(),
-                    None,
-                ),
-            );
-
             // Languages
             Elixir::handle(&project, &mut flake);
             Elm::handle(&project, &mut flake);


### PR DESCRIPTION
While we do want to encourage using flake schemas generally, we shouldn't have a pinned `flake-schemas` input as part of the default init flake.
